### PR TITLE
add model API layer foundation

### DIFF
--- a/src/data/rpc.js
+++ b/src/data/rpc.js
@@ -45,6 +45,7 @@ var utils = require('utils');
 var util = require('util');
 var wait = require('wait.for');
 var gsjsBridge = require('model/gsjsBridge');
+var globalApi = require('model/globalApi');
 
 
 /**
@@ -345,13 +346,7 @@ function objectRequest(callerId, tsid, fname, args, callback) {
  *        the result (or errors) to the remote caller
  */
 function globalApiRequest(callerId, fname, args, callback) {
-	//TODO dummy, replace with actual global API once there is one:
-	var dummyApi = {
-		valueOf: function valueOf() {
-			return 'TODO-DUMMY-API';
-		}
-	};
-	handleRequest(callerId, dummyApi, fname, args, callback);
+	handleRequest(callerId, globalApi, fname, args, callback);
 }
 
 

--- a/src/model/Bag.js
+++ b/src/model/Bag.js
@@ -22,6 +22,7 @@ Bag.prototype.TSID_INITIAL = 'B';
  *        shallow-copied into the bag)
  * @constructor
  * @augments Item
+ * @mixes BagApi
  */
 function Bag(data) {
 	Bag.super_.call(this, data);
@@ -37,6 +38,8 @@ function Bag(data) {
 		this.hiddenItems = utils.arrayToHash(this.hiddenItems);
 	}
 }
+
+utils.copyProps(require('model/BagApi').prototype, Bag.prototype);
 
 
 /**

--- a/src/model/BagApi.js
+++ b/src/model/BagApi.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Model layer API functions for the {@link Bag} class (used by GSJS
+ * code). These functions are attached to `Bag.prototype` at server
+ * startup.
+ *
+ * @mixin
+ */
+var BagApi = module.exports = function BagApi() {};
+
+
+/**
+ * Returns a hash containing all items in this bag (recursively, i.e.
+ * descending into bags inside it), with keys representing the path
+ * to the respective item.
+ *
+ * @returns {object} a hash with all contained items
+ */
+BagApi.prototype.apiGetAllItems = function apiGetAllItems() {
+	log.trace('%s.apiGetAllItems()', this);
+	return this.getAllItems();
+};
+
+
+/**
+ * Add an item to the bag's hidden items list, making it "invisible"
+ * for other API functions working on the bag contents. It can still be
+ * accessed through the `hiddenItems` property.
+ *
+ * @param {Item} item the item to add
+ */
+BagApi.prototype.apiAddHiddenStack = function apiAddHiddenStack(item) {
+	log.debug('%s.apiAddHiddenStack(%s)', this, item);
+	item.setContainer(this, undefined, true);
+};
+
+
+/**
+ * Retrieves a list of items in the bag, i.e. an array with {@link
+ * Item} instances and `null` for empty slots.
+ *
+ * @param {number} [count] length of the inventory to retrieve
+ *        (defaults to the bag capacity)
+ * @returns {array} a list of items corresponding to the bag contents
+ */
+BagApi.prototype.apiGetSlots = function apiGetSlots(count) {
+	log.trace('%s.apiGetSlots(%s)', this, count);
+	return this.getSlots(count);
+};

--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -17,6 +17,7 @@ GameObject.prototype.__isGO = true;
  * @param {object} [data] initialization values (properties are
  *        shallow-copied into the game object)
  * @constructor
+ * @mixes GameObjectApi
  */
 function GameObject(data) {
 	if (!data) data = {};
@@ -48,6 +49,8 @@ function GameObject(data) {
 		this.ts = new Date().getTime();
 	}
 }
+
+utils.copyProps(require('model/GameObjectApi').prototype, GameObject.prototype);
 
 
 /**

--- a/src/model/GameObjectApi.js
+++ b/src/model/GameObjectApi.js
@@ -1,0 +1,59 @@
+'use strict';
+
+
+/**
+ * Model layer API functions for the {@link GameObject} class (used by
+ * GSJS code). These functions are attached to `GameObject.prototype`
+ * at server startup.
+ *
+ * @mixin
+ */
+var GameObjectApi = module.exports = function GameObjectApi() {};
+
+
+/**
+ * Schedules a function of the game object to be called after a given
+ * delay.
+ *
+ * @param {string} fname name of the function to call (must be a method
+ *        of this `GameObject`)
+ * @param {number} delay delay before function call in ms
+ */
+//TODO: append next line to jsdocs when this is fixed: <https://github.com/jscs-dev/jscs-jsdoc/issues/35>
+// * @param {...*} arg arbitrary arguments for the called function
+GameObjectApi.prototype.apiSetTimer = function apiSetTimer(fname, delay) {
+	log.debug('%s.apiSetTimer(%s)', this,
+		Array.prototype.slice.call(arguments).join(', '));
+	//TODO implement me
+	log.warn('TODO GameObject.apiSetTimer not implemented yet');
+};
+
+
+/**
+ * Removes the timer for a function call set by {@link
+ * GameObjectApi#apiSetTimer|apiSetTimer} if there is one.
+ *
+ * @param {string} fname name of the function whose timer to remove
+ * @returns {boolean} `true` if a timer existed and was removed
+ */
+GameObjectApi.prototype.apiCancelTimer = function apiCancelTimer(fname) {
+	log.debug('%s.apiCancelTimer(%s)', this, fname);
+	//TODO implement me
+	log.warn('TODO GameObject.apiCancelTimer not implemented yet');
+	return false;
+};
+
+
+/**
+ * Checks if a timer for a function call (set by {@link
+ * GameObjectApi#apiSetTimer|apiSetTimer}) exists.
+ *
+ * @param {string} fname name of the function to check
+ * @returns {boolean} `true` if a timer exists
+ */
+GameObjectApi.prototype.apiTimerExists = function apiTimerExists(fname) {
+	log.debug('%s.apiTimerExists(%s)', this, fname);
+	//TODO implement me
+	log.warn('TODO GameObject.apiTimerExists not implemented yet');
+	return false;
+};

--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -36,6 +36,7 @@ Object.defineProperty(Item.prototype, 'isStack', {
  *        shallow-copied into the item)
  * @constructor
  * @augments GameObject
+ * @mixes ItemApi
  */
 function Item(data) {
 	Item.super_.call(this, data);
@@ -56,6 +57,8 @@ function Item(data) {
 	}
 	this.updatePath();
 }
+
+utils.copyProps(require('model/ItemApi').prototype, Item.prototype);
 
 
 /**

--- a/src/model/ItemApi.js
+++ b/src/model/ItemApi.js
@@ -1,0 +1,29 @@
+'use strict';
+
+
+/**
+ * Model layer API functions for the {@link Item} class (used by GSJS
+ * code). These functions are attached to `Item.prototype` at server
+ * startup.
+ *
+ * @mixin
+ */
+var ItemApi = module.exports = function ItemApi() {};
+
+
+/**
+ * Retrieves the object that determines the actual position of this
+ * item in its current location. This has three cases:
+ *
+ * * item is in player's inventory: returns player object
+ * * item is in location, outside of any bags: return the item itself
+ * * item is in a bag within a location: return the top-level bag
+ *
+ * @returns {Player|Bag|Item} the game object that determines the
+ *          item's actual x/y position
+ */
+ItemApi.prototype.apiGetLocatableContainerOrSelf =
+	function apiGetLocatableContainerOrSelf() {
+	log.trace('%s.apiGetLocatableContainerOrSelf()', this);
+	return this.getPosObject();
+};

--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -29,6 +29,7 @@ Location.prototype.TSID_INITIAL = 'L';
  *        persistence
  * @constructor
  * @augments GameObject
+ * @mixes LocationApi
  */
 function Location(data, geo) {
 	data = data || {};
@@ -55,6 +56,8 @@ function Location(data, geo) {
 	assert(typeof geoData === 'object', 'no geometry data for ' + this);
 	this.updateGeo(geoData);
 }
+
+utils.copyProps(require('model/LocationApi').prototype, Location.prototype);
 
 
 // dummy property just so we can more easily "inherit" some functions from Bag

--- a/src/model/LocationApi.js
+++ b/src/model/LocationApi.js
@@ -1,0 +1,28 @@
+'use strict';
+
+
+/**
+ * Model layer API functions for the {@link Location} class (used by
+ * GSJS code). These functions are attached to `Location.prototype` at
+ * server startup.
+ *
+ * @mixin
+ */
+var LocationApi = module.exports = function LocationApi() {};
+
+
+/**
+ * Puts the item into the location at the given position, merging it
+ * with existing nearby items of the same class.
+ *
+ * @param {Item} item the item to place
+ * @param {number} x x coordinate of the item's position
+ * @param {number} y y coordinate of the item's position
+ * @param {boolean} [merge] if `false`, item will **not** be merged
+ *        with other nearby items (default behavior if omitted is
+ *        to merge)
+ */
+LocationApi.prototype.apiPutItemIntoPosition =
+	function apiPutItemIntoPosition(item, x, y, merge) {
+	this.addItem(item, x, y, typeof merge === 'boolean' ? !merge : false);
+};

--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -50,6 +50,7 @@ var PROPS_CHANGES = {
  *        shallow-copied into the instance)
  * @constructor
  * @augments Bag
+ * @mixes PlayerApi
  */
 function Player(data) {
 	Player.super_.call(this, data);
@@ -66,6 +67,8 @@ function Player(data) {
 		}
 	}
 }
+
+utils.copyProps(require('model/PlayerApi').prototype, Player.prototype);
 
 
 /**

--- a/src/model/PlayerApi.js
+++ b/src/model/PlayerApi.js
@@ -1,0 +1,70 @@
+'use strict';
+
+
+/**
+ * Model layer API functions for the {@link Player} class (used by GSJS
+ * code). These functions are attached to `Player.prototype` at server
+ * startup.
+ *
+ * @mixin
+ */
+var PlayerApi = module.exports = function PlayerApi() {};
+
+
+/**
+ * Enqueues an announcement for the player.
+ *
+ * @param {object} annc announcement data
+ */
+PlayerApi.prototype.apiSendAnnouncement = function apiSendAnnouncement(annc) {
+	log.debug('%s.apiSendAnnouncement(%s)', this, typeof annc !== 'object' ?
+		'' : (annc.type + '/' + annc.uid));
+	this.queueAnnc(annc);
+};
+
+
+/**
+ * Checks if the player is holding an editing lock for his/her current
+ * location.
+ *
+ * @returns {boolean} `true` if the current location is locked by the
+ *          player
+ */
+PlayerApi.prototype.apiPlayerHasLockForCurrentLocation =
+	function apiPlayerHasLockForCurrentLocation() {
+	log.trace('%s.apiPlayerHasLockForCurrentLocation()', this);
+	//TODO: implement location locking
+	return false;
+};
+
+
+/**
+ * Distribute (part of) an item stack into a range of inventory slots
+ * of either the player itself, or one of its bags, using empty slots
+ * or merging with existing items.
+ *
+ * @param {Item} item item stack to add; may be deleted in the process
+ * @param {number} maxSlot only slots up to this index are considered
+ * @param {string} [path] path to target bag; if `null`, the player
+ *        inventory is targeted
+ * @param {number} [amount] amount of the item stack to add/distribute;
+ *        if not specified, the whole stack is processed
+ * @returns {number} amount of remaining items
+ */
+PlayerApi.prototype.apiAddStackAnywhere =
+	function apiAddStackAnywhere(item, maxSlot, path, amount) {
+	log.debug('%s.apiAddStackAnywhere(%s, %s, %s, %s)', this, item, maxSlot,
+		path, amount);
+	return this.addToAnySlot(item, 0, maxSlot, path, amount);
+};
+
+
+/**
+ * Sends a message to the player's client.
+ *
+ * @param {object} msg the message to send
+ */
+PlayerApi.prototype.apiSendMsg = function apiSendMsg(msg) {
+	log.debug('%s.apiSendMsg', this);
+	this.send(msg);
+};

--- a/src/model/Property.js
+++ b/src/model/Property.js
@@ -16,6 +16,7 @@ var utils = require('utils');
  *        an object containing extended configuration like:
  *        ```{val: 3, bottom: -3, top: 8000}```
  * @constructor
+ * @mixes PropertyApi
  */
 function Property(label, data) {
 	this.label = label;
@@ -36,6 +37,8 @@ function Property(label, data) {
 	// needs to be sent to the client
 	utils.addNonEnumerable(this, 'changed', false);
 }
+
+utils.copyProps(require('model/PropertyApi').prototype, Property.prototype);
 
 
 /**

--- a/src/model/PropertyApi.js
+++ b/src/model/PropertyApi.js
@@ -1,0 +1,72 @@
+'use strict';
+
+
+/**
+ * Model layer API functions for the {@link Property} class (used by
+ * GSJS code). These functions are attached to `Property.prototype` at
+ * server startup.
+ *
+ * @mixin
+ */
+var PropertyApi = module.exports = function PropertyApi() {};
+
+
+/**
+ * Sets the value of the property.
+ *
+ * @param {number} val new value
+ */
+PropertyApi.prototype.apiSet = function apiSet(val) {
+	log.debug('%s.apiSet(%s)', this, val);
+	this.setVal(val);
+};
+
+
+/**
+ * Sets new limits for values of the property.
+ *
+ * @param {number} lo new bottom limit
+ * @param {number} hi new top limit
+ */
+PropertyApi.prototype.apiSetLimits = function apiSetLimits(lo, hi) {
+	log.trace('%s.apiSetLimits(%s, %s)', this, lo, hi);
+	this.setLimits(lo, hi);
+};
+
+
+/**
+ * Increments the value of the property by the given amount.
+ *
+ * @param {number} delta increment by this much
+ * @returns {number} actual delta (may be different from given delta
+ *          due to limits)
+ */
+PropertyApi.prototype.apiInc = function apiInc(delta) {
+	log.debug('%s.apiInc(%s)', this, delta);
+	return this.inc(delta);
+};
+
+
+/**
+ * Decrements the value of the property by the given amount.
+ *
+ * @param {number} delta decrement by this much
+ * @returns {number} actual delta (may be different from given delta
+ *          due to limits)
+ */
+PropertyApi.prototype.apiDec = function apiDec(delta) {
+	log.debug('%s.apiDec(%s)', this, delta);
+	return this.dec(delta);
+};
+
+
+/**
+ * Multiplies the value of the property with the given factor.
+ *
+ * @param {number} factor multiplication factor
+ * @returns {number} value delta
+ */
+PropertyApi.prototype.apiMultiply = function apiMultiply(factor) {
+	log.debug('%s.apiMultiply(%s)', this, factor);
+	return this.mult(factor);
+};

--- a/src/model/globalApi.js
+++ b/src/model/globalApi.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * Global model layer API functions (used by GSJS code).
+ *
+ * @module
+ */
+
+var gsjsBridge = require('model/gsjsBridge');
+var DataContainer = require('model/DataContainer');
+var Item = require('model/Item');
+var Bag = require('model/Bag');
+var pers = require('data/pers');
+
+
+function getItemType(classTsid) {
+	return (classTsid.substr(0, 4) === 'bag_') ? Bag : Item;
+}
+
+
+exports.toString = function toString() {
+	return 'globalApi';
+};
+
+
+/**
+ * Creates a new data container object assigned to a specific owner.
+ *
+ * @param {Location|Player|Group} owner of the DC object
+ * @returns {DataContainer} the new object
+ */
+exports.apiNewOwnedDC = function apiNewOwnedDC(owner) {
+	log.debug('global.apiNewOwnedDC(%s)', owner);
+	return DataContainer.create(owner);
+};
+
+
+/**
+ * Creates a new item (or bag) with the given class.
+ *
+ * @param {string} classTsid ID of the desired item class
+ * @returns {Item|Bag} the new object
+ */
+exports.apiNewItem = function apiNewItem(classTsid) {
+	log.trace('global.apiNewItem(%s, %s)', classTsid);
+	return getItemType(classTsid).create(classTsid);
+};
+
+
+/**
+ * Creates a new stack of a specific item class.
+ *
+ * @param {string} classTsid ID of the desired item class
+ * @param {number} count item stack amount (must be a positive integer)
+ * @returns {Item} the new object
+ */
+exports.apiNewItemStack = function apiNewItemStack(classTsid, count) {
+	log.trace('global.apiNewItemStack(%s, %s)', classTsid, count);
+	return getItemType(classTsid).create(classTsid, count);
+};
+
+
+/**
+ * Retrieves a game object. Throws an Error if no object with the
+ * given TSID is found.
+ *
+ * @param {string} tsid TSID of the desired object
+ * @returns {GameObject} the requested object
+ */
+exports.apiFindObject = function apiFindObject(tsid) {
+	log.trace('global.apiFindObject(%s)', tsid);
+	return pers.get(tsid);
+};
+
+
+/**
+ * Checks if a player is currently online/in-game.
+ *
+ * @param {string} tsid player TSID
+ * @returns {boolean} `true` if the player is online
+ */
+exports.apiIsPlayerOnline = function apiIsPlayerOnline(tsid) {
+	log.debug('global.apiIsPlayerOnline(%s)', tsid);
+	//TODO: implement me
+	log.warn('TODO global.apiIsPlayerOnline not implemented yet');
+	return false;
+};
+
+
+/**
+ * Stores a record with an arbitrary number of fields in a dedicated
+ * game activity log.
+ *
+ */
+//TODO: append next line to jsdocs when this is fixed: <https://github.com/jscs-dev/jscs-jsdoc/issues/35>
+// * @param {...string} field log record field like `"key=somevalue"`
+exports.apiLogAction = function apiLogAction() {
+	log.debug('global.apiLogAction(%s)',
+		Array.prototype.slice.call(arguments).join(', '));
+	//TODO: implement me
+	log.warn('TODO global.apiLogAction not implemented yet');
+};
+
+
+/**
+ * Retrieves the prototype for an item class.
+ *
+ * @param {string} classTsid ID of the desired item class
+ * @returns {object} the prototype object
+ */
+exports.apiFindItemPrototype = function apiFindItemPrototype(classTsid) {
+	log.debug('global.apiFindItemPrototype(%s)', classTsid);
+	return gsjsBridge.getProto('items', classTsid);
+};
+
+
+exports.apiCallMethodForOnlinePlayers =
+	function apiCallMethodForOnlinePlayers(fname, targets) {
+	log.debug('%s.apiCallMethodForOnlinePlayers(%s)', this,
+		Array.prototype.slice.call(arguments).join(', '));
+	//TODO: implement&document me
+	log.warn('TODO global.apiCallMethodForOnlinePlayers not implemented yet');
+	return {ok: 0, error: 'not implemented'};
+
+};
+
+
+// dummy for original GS's CPU profiling function
+//TODO: remove calls from GSJS code
+exports.apiResetThreadCPUClock = function apiResetThreadCPUClock(statName) {
+	log.trace('global.apiResetThreadCPUClock(%s)', statName);
+};

--- a/src/model/gsjsBridge.js
+++ b/src/model/gsjsBridge.js
@@ -50,6 +50,7 @@ var Location = require('model/Location');
 var Quest = require('model/Quest');
 var Geo = require('model/Geo');
 var DataContainer = require('model/DataContainer');
+var globalApi = require('model/globalApi');
 
 
 // require calls are significantly faster with absolute path
@@ -159,12 +160,7 @@ function init(noPreload, callback) {
  * @private
  */
 function initDependencies(testConfig, testApi) {
-	dependencies.api = testApi || {
-		//TODO dummy, replace with actual global API once there is one
-		valueOf: function valueOf() {
-			return 'TODO-DUMMY-API';
-		}
-	};
+	dependencies.api = testApi || globalApi;
 	dependencies.config = compose(testConfig || config.get('gsjs:config'));
 	dependencies.utils = compose('utils');
 	include(GSJS_PATH, 'common');


### PR DESCRIPTION
- each model class has a corresponding *Api.js mixin module, whose
  exported functions are copied to the model class prototype on server
  startup
- the "global" model layer API is in a separate module (globalApi.js)
- the API functions are generally intended to be just a thin layer
  above existing model functionality, hence they should not normally
  require additional tests
