### PR TITLE
add a socket policy server for Flash

### DIFF
--- a/config_base.js
+++ b/config_base.js
@@ -30,6 +30,7 @@ module.exports = {
 			},
 			// add entries here (e.g. gs02, gs03, ...) for additional GS hosts
 		},
+		flashPolicyPort: 1843,
 		assetServer: {
 			host: '127.0.0.1',
 			port: 8000,

--- a/src/comm/policyServer.js
+++ b/src/comm/policyServer.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * A very simple Flash "socket policy server". The Flash runtime needs
+ * to read this policy from any server before allowing the SWF file
+ * (the game client in our case) to establish a TCP socket connection
+ * to that server.
+ *
+ * @see https://www.adobe.com/devnet/flashplayer/articles/socket_policy_files.html
+ *
+ * @module
+ */
+
+// public interface
+module.exports = {
+	start: start,
+};
+
+
+var net = require('net');
+var config = require('config');
+
+var POLICY = '\
+<cross-domain-policy>\n\
+	<site-control permitted-cross-domain-policies="all" />\n\
+	<allow-access-from domain="*" to-ports="*" />\n\
+</cross-domain-policy>\n\x00';
+
+
+function start() {
+	var host = config.get('net:gameServers:' + config.getGsid() + ':host');
+	var port = config.get('net:flashPolicyPort');
+	var server = net.createServer(handleConnect);
+	server.listen(port, host, function onListening() {
+		log.info('policy server listening on %s:%s', host, port);
+	});
+}
+
+
+function handleConnect(socket) {
+	socket.on('data', function onData(data) {
+		if (data.toString().slice(0, 20) === '<policy-file-request') {
+			log.info('Flash policy request from %s:%s',
+				socket.remoteAddress, socket.remotePort);
+			socket.write(POLICY, 'binary');
+		}
+		socket.end();
+	});
+}

--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,7 @@ var gsjsBridge = require('model/gsjsBridge');
 var pers = require('data/pers');
 var rpc = require('data/rpc');
 var amfServer = require('comm/amfServer');
+var policyServer = require('comm/policyServer');
 var logging = require('logging');
 var util = require('util');
 
@@ -98,6 +99,7 @@ function runMaster() {
 		var env = {gsid: id};
 		cluster.fork(env);
 	});
+	policyServer.start();
 }
 
 


### PR DESCRIPTION
This is required so Flash allows the client to open a socket connection to
the GS. Docs on the topic from Adobe:
https://www.adobe.com/devnet/flashplayer/articles/socket_policy_files.html
