### PR TITLE
remove links to missing locations

### DIFF
--- a/src/data/pbe/rethink.js
+++ b/src/data/pbe/rethink.js
@@ -118,15 +118,12 @@ function read(tsid, queryOpts, callback) {
 	if (callback) {
 		// async version
 		runQuery(query, queryOpts, function cb(err, data) {
-			if (!err && !data) log.error(new Error('object not found: ' + tsid));
 			return callback(err, data);
 		});
 	}
 	else {
 		// sync (fibers) version
-		var data = wait.for(runQuery, query, queryOpts);
-		if (!data) log.error(new Error('object not found: ' + tsid));
-		return data;
+		return wait.for(runQuery, query, queryOpts);
 	}
 }
 

--- a/src/model/Geo.js
+++ b/src/model/Geo.js
@@ -61,11 +61,23 @@ Geo.prototype.prepConnects = function prepConnects() {
 			var signpost = mg.signposts[k];
 			for (i in signpost.connects) {
 				signpost.connects[i] = prepConnect(signpost.connects[i]);
+				// remove links to unavailable locations:
+				if (!pers.exists(signpost.connects[i].street_tsid)) {
+					log.info('%s: removing unavailable signpost connect %s',
+						this, signpost.connects[i].street_tsid);
+					delete signpost.connects[i];
+				}
 			}
 		}
 		for (k in mg.doors) {
 			var door = mg.doors[k];
 			door.connect = prepConnect(door.connect);
+			// remove links to unavailable locations:
+			if (!pers.exists(door.connect.street_tsid)) {
+				log.info('%s: removing unavailable door connect %s',
+					this, door.connect.street_tsid);
+				delete mg.doors[k];
+			}
 		}
 	}
 };

--- a/test/func/fixtures/LCR177QO65T1EON.json
+++ b/test/func/fixtures/LCR177QO65T1EON.json
@@ -1,0 +1,5 @@
+{
+    "class_tsid": "town",
+    "label": "Gregarious Grange Subway Station",
+    "tsid": "LCR177QO65T1EON"
+}

--- a/test/func/model/Geo.js
+++ b/test/func/model/Geo.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var path = require('path');
 var pers = require('data/pers');
 var RC = require('data/RequestContext');
 var pbeMock = require('../../mock/pbe');
@@ -10,16 +11,23 @@ var utils = require('utils');
 
 suite('Geo', function () {
 
+	setup(function (done) {
+		pers.init(pbeMock, path.resolve(path.join(__dirname, '../fixtures')), done);
+	});
+
+	teardown(function () {
+		pers.init();  // disable mock back-end
+	});
+
+
 	suite('create', function () {
 
 		setup(function () {
 			gsjsBridge.reset();
-			pers.init(pbeMock);
 		});
 
 		teardown(function () {
 			gsjsBridge.reset();
-			pers.init();  // disable mock back-end
 		});
 
 
@@ -40,11 +48,25 @@ suite('Geo', function () {
 			);
 		});
 
-
 		test('fails with invalid custom TSID', function () {
 			assert.throw(function () {
 				Geo.create({tsid: 'IXYZ'});
 			}, assert.AssertionError);
+		});
+	});
+
+
+	suite('prepConnects', function () {
+
+		this.slow(100);
+
+		test('removes unavailable connects', function (done) {
+			new RC().run(function () {
+				var g = pers.get('GLI32G3NUTD100I');
+				assert.notProperty(g.layers.middleground.doors, 'door_1300484753304');
+				var signpost = g.layers.middleground.signposts.signpost_1;
+				assert.deepEqual(signpost.connects, {});
+			}, done);
 		});
 	});
 });

--- a/test/func/model/Location.js
+++ b/test/func/model/Location.js
@@ -98,7 +98,7 @@ suite('Location', function () {
 				var door = l.clientGeometry.layers.middleground.doors.door_1300233269757;
 				assert.strictEqual(door.connect.street_tsid, 'LCR177QO65T1EON');
 				assert.isTrue(door.connect.target.__isORP);
-				assert.strictEqual(pbeMock.getCounts().read, 2);
+				assert.strictEqual(pbeMock.getCounts().read, 4);
 				assert.strictEqual(pbeMock.getCounts().write, 0);
 				assert.strictEqual(pbeMock.getCounts().del, 0);
 			}, done);

--- a/test/mock/pbe.js
+++ b/test/mock/pbe.js
@@ -45,7 +45,14 @@ function getDB() {
 function read(tsid) {
 	// load test fixture from disk if we have a fixtures path
 	if (fpath && !(tsid in db)) {
-		var data = fs.readFileSync(path.join(fpath, tsid + '.json'));
+		var data;
+		try {
+			data = fs.readFileSync(path.join(fpath, tsid + '.json'));
+		}
+		catch (e) {
+			if (e.code === 'ENOENT') return null;
+			throw e;
+		}
 		db[tsid] = JSON.parse(data);
 	}
 	counts.read++;

--- a/test/unit/model/Geo.js
+++ b/test/unit/model/Geo.js
@@ -3,6 +3,8 @@
 var fs = require('fs');
 var path = require('path');
 var Geo = require('model/Geo');
+var pers = require('data/pers');
+var pbeMock = require('../../mock/pbe');
 
 
 suite('Geo', function () {
@@ -13,6 +15,14 @@ suite('Geo', function () {
 		var data = fs.readFileSync(path.join(FIXTURES_PATH, 'GLI32G3NUTD100I.json'));
 		return JSON.parse(data);
 	}
+
+	setup(function () {
+		pers.init(pbeMock);
+	});
+
+	teardown(function () {
+		pers.init();  // disable mock back-end
+	});
 
 
 	suite('prepConnects', function () {

--- a/test/unit/model/Location.js
+++ b/test/unit/model/Location.js
@@ -5,6 +5,8 @@ var Geo = require('model/Geo');
 var Item = require('model/Item');
 var Bag = require('model/Bag');
 var Player = require('model/Player');
+var pers = require('data/pers');
+var pbeMock = require('../../mock/pbe');
 
 
 suite('Location', function () {
@@ -44,6 +46,14 @@ suite('Location', function () {
 
 
 	suite('updateGeo', function () {
+
+		setup(function () {
+			pers.init(pbeMock);
+		});
+
+		teardown(function () {
+			pers.init();  // disable mock back-end
+		});
 
 		test('does its job', function () {
 			var l = new Location({}, new Geo({layers: {middleground: {doors: {}}}}));


### PR DESCRIPTION
Since we are do not have data files for some locations, "links" to
them (signposts and doors in adjacent locs) need to be removed to
prevent all sorts of errors.
