### PR TITLE
remove inherited properties from GSJS catalog meta items

### DIFF
--- a/src/model/gsjsBridge.js
+++ b/src/model/gsjsBridge.js
@@ -261,7 +261,8 @@ function loadProto(group, klass) {
 	var proto = ctor.prototype;
 	// copy over props from group base class (if applicable)
 	var baseName = group.slice(0, -1);
-	if (group !== 'achievements') {
+	if (group !== 'achievements' &&
+		(group !== 'items' || klass.substr(0, 7) !== 'catalog')) {
 		compose(group, baseName, proto);
 	}
 	// special cases for bags and players
@@ -294,6 +295,7 @@ function getModelClass(group, klass) {
 		case 'groups':
 			return Group;
 		case 'items':
+			if (klass.substr(0, 7) === 'catalog') return;
 			if (klass.substr(0, 3) === 'bag') return Bag;
 			return Item;
 		case 'locations':

--- a/test/func/data/rpc.js
+++ b/test/func/data/rpc.js
@@ -7,6 +7,7 @@ var rpc = rewire('data/rpc');
 var persMock = require('../../mock/pers');
 var rcMock = require('../../mock/RequestContext');
 var GameObject = require('model/GameObject');
+var gsjsBridge = require('model/gsjsBridge');
 
 
 suite('rpc', function () {
@@ -193,6 +194,34 @@ suite('rpc', function () {
 					done();
 				});
 			});
+		});
+	});
+
+
+	suite('model API global function calls', function () {
+
+		setup(function () {
+			config.init(true, CONFIG, {gsjs: {
+				config: 'config_prod',
+			}});
+			gsjsBridge.init(true);
+		});
+
+		teardown(function () {
+			gsjsBridge.reset();
+		});
+
+
+		test('apiFindItemPrototype retrieves catalog objects properly', function (done) {
+			var func = rpc.__get__('globalApiRequest');
+			func('TEST', 'apiFindItemPrototype', ['catalog'],
+				function cb(err, res) {
+					if (err) return done(err);
+					assert.notProperty(res, 'objref');
+					assert.isObject(res, 'class_tsids');
+					done();
+				}
+			);
 		});
 	});
 });

--- a/test/func/model/gsjsBridge.js
+++ b/test/func/model/gsjsBridge.js
@@ -94,6 +94,17 @@ suite('gsjsBridge', function () {
 			assert.isDefined(gsjsBridge.getProto('quests', 'quest'));
 		});
 
+		test('catalog pseudo-objects do not inherit from GameObject', function () {
+			var cat = gsjsBridge.getProto('items', 'catalog');
+			assert.notInstanceOf(cat, GameObject);
+			assert.notInstanceOf(cat, Item);
+			assert.notProperty(cat, 'isBag', 'does not inherit properties from item.js');
+			cat = gsjsBridge.getProto('items', 'catalog_buffs');
+			assert.notInstanceOf(cat, GameObject);
+			assert.notInstanceOf(cat, Item);
+			assert.notProperty(cat, 'isBag', 'does not inherit properties from item.js');
+		});
+
 		test('itemDef is initialized properly', function () {
 			var jar = gsjsBridge.create({class_tsid: 'firefly_jar'}, Item);
 			assert.property(jar, 'itemDef');


### PR DESCRIPTION
Fixes trello#24.

The "catalog" items are special meta items and therefore should not
inherit from the GameObject or Item model classes. This implicitly
fixes the bug where catalog items were serialized to invalid objrefs
when returning them in an RPC function.
