### PR TITLE
don't create invalid objrefs for game object prototypes

### DIFF
--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -8,7 +8,6 @@ var utils = require('utils');
 
 
 GameObject.prototype.TSID_INITIAL = 'G';
-GameObject.prototype.__isGO = true;
 
 /**
  * Generic constructor for both instantiating an existing game object
@@ -31,6 +30,7 @@ function GameObject(data) {
 		utils.addNonEnumerable(this, 'class_id', this.class_tsid);  // deprecated
 	}
 	// add non-enumerable internal properties
+	utils.addNonEnumerable(this, '__isGO', true);
 	utils.addNonEnumerable(this, 'deleted', false);
 	// copy supplied data
 	// TODO: remove 'dynamic' partition in fixture data, and get rid of special handling here


### PR DESCRIPTION
Fixes trello#26.

This makes the API functions for retrieving prototypes of various game
object classes (apiFindItemPrototype, apiFindQuestPrototype,
apiGetJSFileObject) return prototype data correctly.
