### PR TITLE
stub the lynx Timer object when metrics are disabled

### DIFF
--- a/src/metrics.js
+++ b/src/metrics.js
@@ -74,6 +74,11 @@ function getMockLynx() {
 			return function dummy() {
 				if (global.log) {
 					log.trace({fname: name, args: arguments}, 'statsd call');
+					if (name === 'createTimer') {
+						return {
+							stop: function stop() {}
+						};
+					}
 				}
 			};
 		},


### PR DESCRIPTION
Fixes trello#38.
