### PR TITLE
prevent git normalization entirely for npm packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh	eol=lf
+node_modules/**	-text


### PR DESCRIPTION
If the git option "autocrlf" is set to true or input (which seems to be
the default setting on Windows), git normalizes text files to have CRLF
line endings, which breaks shell scripts (e.g. the Bunyan command line
tool). This affects Windows users running the GS in a VM (e.g. in
Vagrant).
To prevent this, turn off any line ending conversion for the
node_modules folder entirely.
