### PR TITLE
restore timers/intervals information in GameObject ctor

### DIFF
--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -35,7 +35,6 @@ function GameObject(data) {
 	// add non-enumerable internal properties
 	utils.addNonEnumerable(this, '__isGO', true);
 	utils.addNonEnumerable(this, 'deleted', false);
-	utils.addNonEnumerable(this, 'gsTimers', {timer: {}, interval: {}});
 	// copy supplied data
 	// TODO: remove 'dynamic' partition in fixture data, and get rid of special handling here
 	var key;
@@ -52,6 +51,10 @@ function GameObject(data) {
 	if (!this.ts) {
 		this.ts = new Date().getTime();
 	}
+	if (!this.gsTimers) this.gsTimers = {};
+	if (!this.gsTimers.timer) this.gsTimers.timer = {};
+	if (!this.gsTimers.interval) this.gsTimers.interval = {};
+	utils.makeNonEnumerable(this, 'gsTimers');
 }
 
 utils.copyProps(require('model/GameObjectApi').prototype, GameObject.prototype);

--- a/test/unit/model/GameObject.js
+++ b/test/unit/model/GameObject.js
@@ -35,6 +35,24 @@ suite('GameObject', function () {
 			assert.strictEqual(go.tsid, 'GXYZ');
 			assert.strictEqual(go.class_tsid, 'something');
 		});
+
+		test('restores serialized timers/intervals', function () {
+			var go = new GameObject({
+				gsTimers: {
+					timer: {
+						foo: 1,
+						bar: 12,
+					},
+					interval: {
+						someInt: {
+							meh: true,
+						},
+					},
+				},
+			});
+			assert.deepEqual(go.gsTimers.timer, {foo: 1, bar: 12});
+			assert.deepEqual(go.gsTimers.interval, {someInt: {meh: true}});
+		});
 	});
 
 


### PR DESCRIPTION
This fixes an error in the GameObject constructor that caused all
existing timers and intervals to be discarded when loading an object
from persistence.
