### PR TITLE
fix incorrect location name in client

### DIFF
--- a/src/model/Geo.js
+++ b/src/model/Geo.js
@@ -146,12 +146,14 @@ function revertConnect(conn) {
  * Creates a shallow data-only copy of the geometry to be made
  * available for the GSJS code as `location.clientGeometry`.
  *
+ * @param {Location} loc location corresponding to this geometry object
  * @returns {object} shallow copy of the geometry data
  */
-Geo.prototype.getClientGeo = function getClientGeo() {
+Geo.prototype.getClientGeo = function getClientGeo(loc) {
 	var ret = utils.shallowCopy(this);
-	// client expects location TSID here:
-	ret.tsid = Location.prototype.TSID_INITIAL + this.tsid.slice(1);
+	// client expects location TSID and label here:
+	ret.tsid = loc.tsid;
+	ret.label = loc.label;
 	return ret;
 };
 

--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -160,7 +160,7 @@ Location.prototype.updateGeo = function updateGeo(data) {
 	// process connects for GSJS
 	this.geometry.prepConnects();
 	// initialize/update clientGeometry and geo properties
-	this.clientGeometry = this.geometry.getClientGeo();
+	this.clientGeometry = this.geometry.getClientGeo(this);
 	this.geo = this.geometry.getGeo();
 };
 

--- a/test/unit/model/Geo.js
+++ b/test/unit/model/Geo.js
@@ -158,11 +158,13 @@ suite('Geo', function () {
 
 		test('does its job', function () {
 			var g = new Geo(getSampleData());
-			var cg = g.getClientGeo();
+			var mockLoc = {tsid: 'LLI32G3NUTD100I', label: 'Back Alley'};
+			var cg = g.getClientGeo(mockLoc);
 			assert.property(cg.layers.middleground, 'doors');
 			assert.property(cg.layers.middleground, 'signposts');
 			assert.notProperty(cg, 'serialize', 'does not contain functions');
 			assert.strictEqual(cg.tsid, 'LLI32G3NUTD100I', 'has location TSID');
+			assert.strictEqual(cg.label, 'Back Alley', 'has location label');
 			cg.foo = 'doodle';
 			assert.notProperty(g, 'foo', 'is a copy');
 		});


### PR DESCRIPTION
The client displays the location name based on the 'label' property of
the 'clientGeometry' data, which is set to something odd for some
locations in the geometry object, so just always set it to the location
label explicitly.
