### PR TITLE
release unused objects from live object cache

### DIFF
--- a/config_base.js
+++ b/config_base.js
@@ -43,6 +43,14 @@ module.exports = {
 		// incoming AMF messages bigger than this are considered invalid
 		maxMsgSize: 131072,
 	},
+	pers: {
+		pack: {
+			// how often to release "old" objects from live object cache
+			interval: 30000,  // ms
+			// objects that have not been modified this long are considered old
+			ttl: 300000,  // ms
+		},
+	},
 	log: {
 		// dir can be an absolute path, or relative to eleven-server directory
 		dir: './log',

--- a/src/data/persProxy.js
+++ b/src/data/persProxy.js
@@ -74,20 +74,23 @@ function makeProxy(obj, prop) {
 			// only set dirty flag for actual value changes
 			if (val !== target[name]) {
 				target[name] = val;
-				if (name[0] !== '!' && target.propertyIsEnumerable(name)) {
+				if (name[0] !== '!' && name !== 'ts' &&
+					target.propertyIsEnumerable(name)) {
 					// performance hack: don't persist x/y changes for players
 					if (target !== obj || obj.tsid[0] !== 'P' ||
 						(name !== 'x' && name !== 'y')) {
 						RC.getContext().setDirty(obj);
+						obj.ts = new Date().getTime();
 					}
 				}
 			}
 		},
 		deleteProperty: function deleteProperty(target, name) {
 			if (name in target) {
-				if (name[0] !== '!' && target.hasOwnProperty(name) &&
+				if (name[0] !== '!' && name !== 'ts' && target.hasOwnProperty(name) &&
 					target.propertyIsEnumerable(name)) {
 					RC.getContext().setDirty(obj);
+					obj.ts = new Date().getTime();
 				}
 				return delete target[name];
 			}

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -14,6 +14,7 @@ module.exports = {
 	init: init,
 	increment: increment,
 	decrement: decrement,
+	count: count,
 	createTimer: createTimer,
 	setupGaugeInterval: setupGaugeInterval,
 	setupTimerInterval: setupTimerInterval,
@@ -104,6 +105,16 @@ function increment(stats, sampleRate) {
  */
 function decrement(stats, sampleRate) {
 	return lynx.decrement(stats, sampleRate);
+}
+
+
+/**
+ * Change a counter metric by an arbitrary delta.
+ * see {@link https://github.com/dscape/lynx/ lynx} and {@link
+ * https://github.com/etsy/statsd statsd} docs for details.
+ */
+function count(stats, delta, sampleRate) {
+	return lynx.count(stats, delta, sampleRate);
 }
 
 

--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -48,9 +48,7 @@ function GameObject(data) {
 			this[key] = data[key];
 		}
 	}
-	if (!this.ts) {
-		this.ts = new Date().getTime();
-	}
+	this.ts = new Date().getTime();
 	if (!this.gsTimers) this.gsTimers = {};
 	if (!this.gsTimers.timer) this.gsTimers.timer = {};
 	if (!this.gsTimers.interval) this.gsTimers.interval = {};
@@ -189,7 +187,7 @@ GameObject.prototype.setGsTimer = function setGsTimer(options) {
 	var type = options.interval ? 'interval' : 'timer';
 	assert(!(options.multi && options.interval), 'multi intervals not supported');
 	assert(!(options.multi && options.internal), 'internal multi timers not supported');
-	assert(typeof this[options.fname] === 'function', 'no such function: %s', logtag);
+	assert(typeof this[options.fname] === 'function', 'no such function: ' + logtag);
 	if (!options.multi && this.gsTimerExists(options.fname, options.interval)) {
 		log.trace('timer/interval already set: %s', logtag);
 		return;
@@ -331,4 +329,20 @@ GameObject.prototype.cancelGsTimer = function cancelGsTimer(fname, interval) {
 		delete this.gsTimers[type][fname];
 	}
 	return ret;
+};
+
+
+/**
+ * Checks if there are any pending timers calls/active interval calls
+ * on this object.
+ *
+ * @returns {boolean} `true` if there are active timers/intervals
+ */
+GameObject.prototype.hasActiveGsTimers = function hasActiveGsTimers() {
+	for (var type in this.gsTimers) {
+		for (var key in this.gsTimers[type]) {
+			if (this.gsTimers[type][key].handle) return true;
+		}
+	}
+	return false;
 };

--- a/src/server.js
+++ b/src/server.js
@@ -64,8 +64,7 @@ function loadPluggable(modPath, logtag) {
 function persInit(callback) {
 	var modName = config.get('pers:backEnd:module');
 	var pbe = loadPluggable('data/pbe/' + modName, 'persistence back-end');
-	var pbeConfig = config.get('pers:backEnd:config:' + modName);
-	pers.init(pbe, pbeConfig, function cb(err, res) {
+	pers.init(pbe, config.get('pers'), function cb(err, res) {
 		if (err) log.error(err, 'persistence layer initialization failed');
 		else log.info('persistence layer initialized (%s back-end)', modName);
 		callback(err);

--- a/test/func/comm/Session.js
+++ b/test/func/comm/Session.js
@@ -95,7 +95,12 @@ suite('Session', function () {
 		});
 
 		setup(function (done) {
-			pers.init(pbeMock, path.resolve(path.join(__dirname, '../fixtures')), done);
+			pers.init(pbeMock, {backEnd: {
+				module: 'pbeMock',
+				config: {pbeMock: {
+					fixturesPath: path.resolve(path.join(__dirname, '../fixtures')),
+				}}
+			}}, done);
 		});
 
 		teardown(function () {

--- a/test/func/model/GameObject.js
+++ b/test/func/model/GameObject.js
@@ -24,10 +24,11 @@ suite('GameObject', function () {
 			assert.property(go, 'layers');
 		});
 
-		test('keeps timestamp from data if there is one', function () {
+		test('creates or updates timestamp', function () {
+			assert.isTrue(new GameObject().ts >= new Date().getTime());
 			var data = getFixtureJson('GIFPV9EMLT72DP4.json');
 			var go = new GameObject(data);
-			assert.strictEqual(go.ts, data.ts);
+			assert.isTrue(go.ts > data.ts);
 		});
 	});
 
@@ -37,7 +38,9 @@ suite('GameObject', function () {
 		test('serialized data is equivalent to source data', function () {
 			var data = getFixtureJson('IHFK8C8NB6J2FJ5.json');
 			var go = new GameObject(data);
-			assert.deepEqual(go.serialize(), data);
+			var ser = go.serialize();
+			ser.ts = data.ts;
+			assert.deepEqual(ser, data);
 		});
 	});
 
@@ -45,7 +48,6 @@ suite('GameObject', function () {
 	suite('timers', function () {
 
 		test('basic timer call', function (done) {
-			//TODO: test combining setGsTimer and scheduleTimer
 			var go = new GameObject();
 			var called = false;
 			go.timerTest = function timerTest(arg) {

--- a/test/func/model/Geo.js
+++ b/test/func/model/Geo.js
@@ -12,7 +12,12 @@ var utils = require('utils');
 suite('Geo', function () {
 
 	setup(function (done) {
-		pers.init(pbeMock, path.resolve(path.join(__dirname, '../fixtures')), done);
+		pers.init(pbeMock, {backEnd: {
+			module: 'pbeMock',
+			config: {pbeMock: {
+				fixturesPath: path.resolve(path.join(__dirname, '../fixtures')),
+			}}
+		}}, done);
 	});
 
 	teardown(function () {

--- a/test/func/model/Location.js
+++ b/test/func/model/Location.js
@@ -35,7 +35,12 @@ suite('Location', function () {
 		this.slow(4000);
 
 		setup(function (done) {
-			pers.init(pbeMock, path.resolve(path.join(__dirname, '../fixtures')), done);
+			pers.init(pbeMock, {backEnd: {
+				module: 'pbeMock',
+				config: {pbeMock: {
+					fixturesPath: path.resolve(path.join(__dirname, '../fixtures')),
+				}}
+			}}, done);
 		});
 
 		teardown(function () {

--- a/test/mock/pbe.js
+++ b/test/mock/pbe.js
@@ -20,8 +20,10 @@ var db = {};
 var counts = {};
 
 
-function init(fixturePath, callback) {
-	fpath = fixturePath;
+function init(pbeConfig, callback) {
+	if (typeof pbeConfig === 'object') {
+		fpath = pbeConfig.fixturesPath;
+	}
 	db = {};
 	counts = {
 		read: 0,

--- a/test/unit/data/pers.js
+++ b/test/unit/data/pers.js
@@ -234,4 +234,30 @@ suite('pers', function () {
 			});
 		});
 	});
+
+
+	suite('pack', function () {
+
+		test('works as expected', function (done) {
+			var pack = pers.__get__('pack');
+			var o1 = new GameObject({tsid: 'I1'});
+			var o2 = new GameObject({tsid: 'I2'});
+			pers.__set__('cache', {I1: o1, I2: o2});
+			pack(100);
+			assert.deepEqual(Object.keys(pers.__get__('cache')), ['I1', 'I2'],
+				'nothing released from cache (both objects younger than TTL)');
+			setTimeout(function () {
+				o2.ts = new Date().getTime();  // fake modification of I2
+				pack(7);
+				assert.deepEqual(Object.keys(pers.__get__('cache')), ['I2'],
+					'I1 released from cache');
+				setTimeout(function () {
+					pack(8);
+					assert.strictEqual(Object.keys(pers.__get__('cache')).length, 0,
+						'everything released from cache');
+					done();
+				}, 10);
+			}, 10);
+		});
+	});
 });

--- a/test/unit/data/persProxy.js
+++ b/test/unit/data/persProxy.js
@@ -136,7 +136,7 @@ suite('persProxy', function () {
 			var p = pp.makeProxy(o);
 			p.arr[0].x = 3;
 			assert.strictEqual(JSON.stringify(p),
-				'{"tsid":"x","arr":[{"x":3},[1,2,3]]}');
+				'{"tsid":"x","arr":[{"x":3},[1,2,3]],"ts":' + p.ts + '}');
 		});
 
 		test('pproxy does not break Array.sort', function () {
@@ -148,6 +148,22 @@ suite('persProxy', function () {
 			assert.deepEqual(sorted, ['spriggan', 'humbaba', 'cosma', 'alph']);
 		});
 
+		test('set and del operations update timestamp', function (done) {
+			var ts = new Date().getTime();
+			var o1 = {tsid: 'x', a: 7, ts: ts};
+			var o2 = {tsid: 'x', a: 7, ts: ts};
+			var p1 = pp.makeProxy(o1);
+			var p2 = pp.makeProxy(o2);
+			setTimeout(function () {
+				p1.a = 8;
+				assert.notStrictEqual(o1.ts, ts);
+				assert.isTrue(o1.ts > ts);
+				delete p2.a;
+				assert.notStrictEqual(o2.ts, ts);
+				assert.isTrue(o2.ts > ts);
+				done();
+			}, 3);
+		});
 	});
 
 

--- a/test/unit/model/GameObject.js
+++ b/test/unit/model/GameObject.js
@@ -360,4 +360,32 @@ suite('GameObject', function () {
 			}, 20);
 		});
 	});
+
+
+	suite('hasActiveGsTimers', function () {
+
+		test('works with timers', function (done) {
+			var go = new GameObject();
+			assert.isFalse(go.hasActiveGsTimers());
+			go.foo = function foo() {
+				assert.isFalse(go.hasActiveGsTimers());
+				done();
+			};
+			go.setGsTimer({fname: 'foo', delay: 10});
+			assert.isTrue(go.hasActiveGsTimers());
+		});
+
+		test('works with intervals', function (done) {
+			var go = new GameObject();
+			assert.isFalse(go.hasActiveGsTimers());
+			go.foo = function foo() {
+				assert.isTrue(go.hasActiveGsTimers());
+				go.cancelGsTimer('foo', true);
+				assert.isFalse(go.hasActiveGsTimers());
+				done();
+			};
+			go.setGsTimer({fname: 'foo', delay: 5, interval: true});
+			assert.isTrue(go.hasActiveGsTimers());
+		});
+	});
 });

--- a/test/unit/model/Geo.js
+++ b/test/unit/model/Geo.js
@@ -132,6 +132,7 @@ suite('Geo', function () {
 
 		test('returns data equivalent to original input data', function () {
 			var ser = new Geo(getSampleData()).serialize();
+			ser.ts = getSampleData().ts;
 			assert.deepEqual(ser, getSampleData());
 		});
 

--- a/test/unit/model/Item.js
+++ b/test/unit/model/Item.js
@@ -91,7 +91,6 @@ suite('Item', function () {
 			var data = {
 				tsid: 'IFOO',
 				label: 'Teapot',
-				ts: 12345,
 				count: 1,
 				x: 123,
 				y: 456,
@@ -99,7 +98,9 @@ suite('Item', function () {
 			};
 			var i = new Item(data);
 			delete data.onPlayerCollision;  // functions are not included in serialization
-			assert.deepEqual(i.serialize(), data);
+			var ser = i.serialize();
+			delete ser.ts;
+			assert.deepEqual(ser, data);
 		});
 	});
 


### PR DESCRIPTION
Periodically sweep through the live object cache in the persistence
module, releasing objects that have not been modified for a certain
amount of time (except if there are active timers or intervals on the
object).
