### PR TITLE
log apiLogAction calls to separate logfile

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ module.exports = {
 	init: init,
 	get: get,
 	getGsid: getGsid,
+	getMasterGsid: getMasterGsid,
 	getGSConf: getGSConf,
 	forEachGS: forEachGS,
 	forEachLocalGS: forEachLocalGS,
@@ -178,6 +179,17 @@ function setGsid(id) {
  */
 function getGsid() {
 	return gsid;
+}
+
+
+/**
+ * Returns the ID of the master GS this process "belongs to".
+ *
+ * @returns {string} ID of the master GS for this process
+ */
+function getMasterGsid() {
+	if (gsid.indexOf('-') === -1) return gsid;  // master process itself
+	return gsid.substr(0, gsid.lastIndexOf('-'));
 }
 
 

--- a/src/model/globalApi.js
+++ b/src/model/globalApi.js
@@ -17,6 +17,7 @@ var Group = require('model/Group');
 var pers = require('data/pers');
 var orProxy = require('data/objrefProxy');
 var utils = require('utils');
+var logging = require('logging');
 var lodash = require('lodash');
 
 
@@ -198,14 +199,12 @@ exports.apiIsPlayerOnline = function apiIsPlayerOnline(tsid) {
  * Stores a record with an arbitrary number of fields in a dedicated
  * game activity log.
  *
+ * @param {string} type activity/action type to log (arbitrary string)
+ * @param {...string} field log record field like `"key=somevalue"`
  */
-//TODO: append next line to jsdocs when this is fixed: <https://github.com/jscs-dev/jscs-jsdoc/issues/35>
-// * @param {...string} field log record field like `"key=somevalue"`
-exports.apiLogAction = function apiLogAction() {
-	log.debug('global.apiLogAction(%s)',
-		Array.prototype.slice.call(arguments).join(', '));
-	//TODO: implement me
-	log.warn('TODO global.apiLogAction not implemented yet');
+exports.apiLogAction = function apiLogAction(type) {
+	log.trace('global.apiLogAction()');
+	logging.logAction(type, Array.prototype.slice.call(arguments, 1));
 };
 
 

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -209,14 +209,14 @@ suite('config', function () {
 
 	suite('getGSConf', function () {
 
-		test('does its job (master server)', function () {
+		test('does its job (master)', function () {
 			config.init(true, {net: {gameServers: {gs1: {host: '127.0.0.1',
 				ports: [1]}}}}, {});
 			assert.strictEqual(config.getGSConf(), undefined,
 				'no GS config entry for master server');
 		});
 
-		test('does its job (worker server)', function () {
+		test('does its job (worker)', function () {
 			config.init(false, {
 				net: {gameServers: {
 					gs1: {host: '127.0.0.1', ports: [1]},
@@ -235,6 +235,28 @@ suite('config', function () {
 			assert.throw(function () {
 				config.getGSConf('blurb');
 			}, assert.AssertionError);
+		});
+	});
+
+
+	suite('getMasterGsid', function () {
+
+		test('works as expected (master)', function () {
+			config.init(true, {
+				net: {gameServers: {
+					gs1: {host: '127.0.0.1', ports: [1, 2]},
+				}},
+			}, {});
+			assert.strictEqual(config.getMasterGsid(), 'gs1');
+		});
+
+		test('works as expected (worker)', function () {
+			config.init(false, {
+				net: {gameServers: {
+					gs1: {host: '127.0.0.1', ports: [1, 2]},
+				}},
+			}, {gsid: 'gs1-01'});
+			assert.strictEqual(config.getMasterGsid(), 'gs1');
 		});
 	});
 });

--- a/test/unit/logging.js
+++ b/test/unit/logging.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var rewire = require('rewire');
+var logging = rewire('logging');
+
+
+suite('logging', function () {
+
+
+	suite('logAction', function () {
+
+		var origActionLogger;
+
+
+		setup(function () {
+			origActionLogger = logging.__get__('actionLogger');
+		});
+
+		teardown(function () {
+			logging.__set__('actionLogger', origActionLogger);
+		});
+
+
+		test('works as expected', function (done) {
+			logging.__set__('actionLogger', {
+				info: function info(fields, msg) {
+					assert.strictEqual(msg, 'XYZ');
+					assert.deepEqual(fields,
+						{action: 'XYZ', abc: '12', def: 'foo'});
+					done();
+				},
+			});
+			logging.logAction('XYZ', ['abc=12', 'def=foo']);
+		});
+
+		test('handles improperly formatted fields gracefully', function (done) {
+			logging.__set__('actionLogger', {
+				info: function info(fields, msg) {
+					assert.strictEqual(msg, 'meh');
+					assert.deepEqual(fields,
+						{action: 'meh', 'UNKNOWN#0': 'barf', 'UNKNOWN#1': '123',
+						'UNKNOWN#2': 'null', 'UNKNOWN#3': 'undefined'});
+					done();
+				},
+			});
+			logging.logAction('meh', ['barf', 123, null, undefined]);
+		});
+
+		test('fails on invalid action parameter', function () {
+			assert.throw(function () {
+				logging.logAction();
+			}, assert.AssertionError);
+		});
+	});
+});


### PR DESCRIPTION
* write game events logged via global API function apiLogAction to a
  dedicated log file
* combine logs for all worker processes into shared log files (easier
  to read/handle, and no real downside as long as log rotation is done
  with an external tool, e.g. logrotate)