### PR TITLE
don't send changes for invisible items

### DIFF
--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -455,6 +455,10 @@ Player.prototype.addToAnySlot = function addToAnySlot(item, fromSlot, toSlot,
  */
 Player.prototype.queueChanges = function queueChanges(item, removed, compact) {
 	log.trace('generating changes for %s%s', item, removed ? ' (removed)' : '');
+	if (item.only_visible_to && item.only_visible_to !== this.tsid) {
+		log.trace('%s not visible for %s, skipping', item, this);
+		return;
+	}
 	var pcChanges = {};
 	var locChanges = {};
 	if (item.tcont === this.tsid) {

--- a/test/func/model/Player.js
+++ b/test/func/model/Player.js
@@ -195,6 +195,16 @@ suite('Player', function () {
 					p.changes[1].itemstack_values.location[it.tsid].count, 0);
 			}, done);
 		});
+
+		test('skips items not visible for the player', function (done) {
+			new RC().run(function () {
+				var p = new Player({tsid: 'PX', location: {tsid: 'LX'}});
+				var it = new Item({tsid: 'IX', class_tsid: 'quoin', tcont: 'LX',
+					only_visible_to: 'POTHER'});
+				p.queueChanges(it);
+				assert.lengthOf(p.changes, 0);
+			}, done);
+		});
 	});
 
 


### PR DESCRIPTION
* for items with the "only_visible_to" property, only send changes
  to the player who can actually see them