### PR TITLE
prevent timers on unloaded objects from firing

### DIFF
--- a/src/data/RequestContext.js
+++ b/src/data/RequestContext.js
@@ -8,6 +8,7 @@ var util = require('util');
 var wait = require('wait.for');
 var Fiber = require('wait.for/node_modules/fibers');
 var pers = require('data/pers');
+var utils = require('utils');
 
 
 /**
@@ -165,6 +166,7 @@ RequestContext.prototype.setDirty = function setDirty(obj) {
  * @param {GameObject} obj
  */
 RequestContext.prototype.setUnload = function setUnload(obj) {
+	utils.addNonEnumerable(obj, 'stale', true);
 	this.unload[obj.tsid] = obj;
 };
 

--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -35,6 +35,7 @@ function GameObject(data) {
 	// add non-enumerable internal properties
 	utils.addNonEnumerable(this, '__isGO', true);
 	utils.addNonEnumerable(this, 'deleted', false);
+	utils.addNonEnumerable(this, 'stale', false);
 	// copy supplied data
 	var key;
 	for (key in data) {
@@ -225,6 +226,13 @@ GameObject.prototype.scheduleTimer = function scheduleTimer(options, type, key) 
 			rc.run(
 				function timerCall() {
 					log.trace({options: options}, '%s call', type);
+					if (self.stale) {
+						if (options.interval) {
+							clearInterval(self.gsTimers[type][key].handle);
+						}
+						delete self.gsTimers[type][key];
+						throw new Error('stale object');
+					}
 					if (!options.interval) {
 						delete self.gsTimers[type][key];
 					}

--- a/test/func/model/GameObject.js
+++ b/test/func/model/GameObject.js
@@ -70,5 +70,38 @@ suite('GameObject', function () {
 			});
 			assert.strictEqual(calls, 0);
 		});
+
+		test('timers on stale objects are not executed', function (done) {
+			var go = new GameObject();
+			var called = false;
+			go.foo = function () {
+				called = true;
+			};
+			go.setGsTimer({fname: 'foo', delay: 5});
+			setTimeout(function () {
+				assert.isTrue(go.stale);
+				assert.isFalse(called);
+				done();
+			}, 10);
+			go.stale = true;
+		});
+
+		test('intervals on stale objects are cleared', function (done) {
+			var go = new GameObject();
+			var calledOnStale = false;
+			var c = 0;
+			go.foo = function () {
+				c++;
+				if (go.stale) calledOnStale = true;
+				go.stale = true;
+			};
+			go.setGsTimer({fname: 'foo', delay: 5, interval: true});
+			setTimeout(function () {
+				assert.isTrue(go.stale);
+				assert.strictEqual(c, 1);
+				assert.isFalse(calledOnStale);
+				done();
+			}, 20);
+		});
 	});
 });

--- a/test/unit/data/RequestContext.js
+++ b/test/unit/data/RequestContext.js
@@ -114,6 +114,7 @@ suite('RequestContext', function () {
 				},
 				function callback() {
 					assert.deepEqual(persMock.getUnloadList(), {IA: {tsid: 'IA'}});
+					assert.isTrue(persMock.getUnloadList().IA.stale);
 					assert.deepEqual(persMock.getDirtyList(), {},
 						'objects to unload are *not* implicitly flagged dirty');
 				}


### PR DESCRIPTION
Mark objects with a 'stale' flag when unloading them, so
timer/interval calls can detect when they are firing on an already
unloaded object and abort the call.