### PR TITLE
prevent setting NaN as item coordinates

### DIFF
--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -132,6 +132,7 @@ Item.prototype.updatePath = function updatePath() {
  * @returns {boolean} `true` if the item's coordinates actually changed
  */
 Item.prototype.setXY = function setXY(x, y) {
+	assert(!isNaN(x) && !isNaN(y), 'invalid coordinates');
 	if (this.itemDef && this.itemDef.obey_physics && utils.isLoc(this.container)) {
 		var pp = this.container.geometry.getClosestPlatPoint(x, y, -1, true);
 		if (pp && pp.point) {

--- a/test/func/model/Bag.js
+++ b/test/func/model/Bag.js
@@ -182,7 +182,7 @@ suite('Bag', function () {
 				var p = new Player({tsid: 'PX', location: l});
 				l.players[p.tsid] = rc.cache[p.tsid] = p;
 				var fbag = Bag.create('bag_bigger_green');
-				fbag.setContainer(l);
+				fbag.setContainer(l, 1, 2);
 				var i = Item.create('pi');
 				var bag = Bag.create('bag_bigger_gray');
 				bag.setContainer(p, 1);

--- a/test/func/model/Item.js
+++ b/test/func/model/Item.js
@@ -246,7 +246,7 @@ suite('Item', function () {
 				assert.strictEqual(it.getChangeData().slot, 3);
 				it.x = 0;
 				assert.strictEqual(it.getChangeData().slot, 0);
-				it.setContainer(l);
+				it.setContainer(l, 1, 2);
 				assert.notProperty(it.getChangeData(), 'slot');
 			}, done);
 		});

--- a/test/func/model/Location.js
+++ b/test/func/model/Location.js
@@ -197,8 +197,8 @@ suite('Location', function () {
 					i2 = Item.create('banana');
 					b = new Bag({class_tsid: 'bag_bigger_green', items: [i2]});
 					l = Location.create(Geo.create());
-					l.addItem(i1);
-					l.addItem(b);
+					l.addItem(i1, 12, 13);
+					l.addItem(b, 12, 13);
 					l.unload();
 				},
 				function callback(err, res) {

--- a/test/unit/model/Item.js
+++ b/test/unit/model/Item.js
@@ -167,7 +167,7 @@ suite('Item', function () {
 		test('ignores slot property when adding to a location', function () {
 			var it = getTestItem('IT');
 			var l = new Location({}, new Geo());
-			it.setContainer(l);
+			it.setContainer(l, 123, 456);
 			assert.isUndefined(it.slot);
 			it.container = undefined;  // just so we can try again
 			it.setContainer(l, 13, 29);
@@ -214,7 +214,7 @@ suite('Item', function () {
 				assert.strictEqual(curr.tsid, 'BX');
 				done();
 			};
-			it.setContainer(new Location({tsid: 'LX'}, new Geo()));  // does not trigger onContainerChanged (no previous container)
+			it.setContainer(new Location({tsid: 'LX'}, new Geo()), 0, 0);  // does not trigger onContainerChanged (no previous container)
 			it.setContainer(new Bag({tsid: 'BX', tcont: 'LDUMMY'}), 3, 7);
 		});
 
@@ -222,15 +222,15 @@ suite('Item', function () {
 			var l = new Location({tsid: 'LX'}, new Geo());
 			var l2 = new Location({tsid: 'LY'}, new Geo());
 			var it1 = getTestItem('IT1');
-			it1.setContainer(l);
+			it1.setContainer(l, 123, 456);
 			var it2 = getTestItem('IT2');
-			it2.setContainer(l2);
+			it2.setContainer(l2, 123, 456);
 			it1.onContainerItemAdded = function (it, prevCont) {
 				assert.strictEqual(it.tsid, 'IT2');
 				assert.strictEqual(prevCont.tsid, 'LY');
 				done();
 			};
-			it2.setContainer(l);
+			it2.setContainer(l, 123, 456);
 		});
 
 		test('sends appropriate onContainerItemRemoved events', function (done) {


### PR DESCRIPTION
Fail immediately when something is trying to set NaN as an item's x or y
coordinate (otherwise RethinkDB just fails writing the values later on)