### PR TITLE
remove the "offline player removal" hack

### DIFF
--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -494,13 +494,6 @@ Player.prototype.send = function send(msg, skipChanges, flushOnly) {
 	if (!this.session) {
 		log.info(new Error('dummy error for stack trace'),
 			'trying to send message to offline player %s', this);
-		if (this.location && this.tsid in this.location.players) {
-			// clean up players "stuck" in a location after a previous error
-			// (asynchronously, in order not to interfere with the current request)
-			log.warn('scheduling offline player removal for %s in %s', this,
-				this.location);
-			this.setGsTimer({fname: 'onDisconnect', delay: 100, internal: true});
-		}
 		return;
 	}
 	// generage "changes" segment


### PR DESCRIPTION
This error recovery feature makes GS behavior in other situations worse,
see e.g. https://trello.com/c/LyoLOUID so remove it for the time being.
Calling `onDisconnect` after a basically arbitrary delay (100ms), with
no further questions asked, seems like a bad idea anyway; it might be
better to handle the general issue ("old" player instances stuck in
locations after errors) from the location side.