### PR TITLE
Give players physics upgrades on reset/creation

### DIFF
--- a/src/data/rpcApi.js
+++ b/src/data/rpcApi.js
@@ -168,6 +168,8 @@ function resetPlayer(tsid) {
 function makeAlphaAdjustments(pc) {
 	pc.teleportToLocation(NEW_PLAYER_LOC, 2750, -55);
 	pc.stats.currants.setVal(100000);
+	delete pc.use_img;
+	pc.adminBackfillNewxpPhysics();
 }
 
 


### PR DESCRIPTION
Calling adminBackfillNewxpPhysics will give players the basic physics upgrades on a reset or on creation (plus the physics upgrade cards don't show up in the card pool).