### PR TITLE
don't queue changes&announcements for offline players

### DIFF
--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -442,6 +442,7 @@ Player.prototype.addToAnySlot = function addToAnySlot(item, fromSlot, toSlot,
  *        (only coordinates and state, for NPC movement)
  */
 Player.prototype.queueChanges = function queueChanges(item, removed, compact) {
+	if (!this.session) return;  // don't queue changes for offline players
 	log.trace('generating changes for %s%s', item, removed ? ' (removed)' : '');
 	if (item.only_visible_to && item.only_visible_to !== this.tsid) {
 		log.trace('%s not visible for %s, skipping', item, this);
@@ -474,6 +475,7 @@ Player.prototype.queueChanges = function queueChanges(item, removed, compact) {
  * @param {object} annc announcement data
  */
 Player.prototype.queueAnnc = function queueAnnc(annc) {
+	if (!this.session) return;  // don't queue announcements for offline players
 	log.trace({annc: annc}, 'queueing annc');
 	this.anncs.push(annc);
 };

--- a/test/func/comm/Session.js
+++ b/test/func/comm/Session.js
@@ -6,13 +6,13 @@ var abePassthrough = require('comm/abe/passthrough');
 var net = require('net');
 var path = require('path');
 var config = require('config');
-var helpers = require('../../helpers');
 var RC = require('data/RequestContext');
 var Session = require('comm/Session');
 var sessionMgr = require('comm/sessionMgr');
 var pers = require('data/pers');
 var pbeMock = require('../../mock/pbe');
 var gsjsBridge = require('model/gsjsBridge');
+var helpers = require('../../helpers');
 
 
 suite('Session', function () {

--- a/test/func/model/Bag.js
+++ b/test/func/model/Bag.js
@@ -10,6 +10,7 @@ var Geo = require('model/Geo');
 var pers = require('data/pers');
 var utils = require('utils');
 var pbeMock = require('../../mock/pbe');
+var helpers = require('../../helpers');
 
 
 suite('Bag', function () {
@@ -179,7 +180,7 @@ suite('Bag', function () {
 			var rc = new RC();
 			rc.run(function () {
 				var l = Location.create(Geo.create());
-				var p = new Player({tsid: 'PX', location: l});
+				var p = helpers.getOnlinePlayer({tsid: 'PX', location: l});
 				l.players[p.tsid] = rc.cache[p.tsid] = p;
 				var fbag = Bag.create('bag_bigger_green');
 				fbag.setContainer(l, 1, 2);

--- a/test/func/model/Item.js
+++ b/test/func/model/Item.js
@@ -11,6 +11,7 @@ var Geo = require('model/Geo');
 var pers = require('data/pers');
 var utils = require('utils');
 var pbeMock = require('../../mock/pbe');
+var helpers = require('../../helpers');
 
 
 suite('Item', function () {
@@ -106,7 +107,8 @@ suite('Item', function () {
 		test('queues appropriate changes', function (done) {
 			var rc = new RC();
 			rc.run(function () {
-				var p = new Player({tsid: 'PX', location: {tsid: 'LDUMMY'}});
+				var p = helpers.getOnlinePlayer(
+					{tsid: 'PX', location: {tsid: 'LDUMMY'}});
 				rc.cache[p.tsid] = p;  // add to RC cache so pers.get('PX') works
 				var it = new Item(
 					{tsid: 'IX', class_tsid: 'meat', count: 5, tcont: 'PX'});
@@ -182,7 +184,8 @@ suite('Item', function () {
 		test('queues appropriate changes', function (done) {
 			var rc = new RC();
 			rc.run(function () {
-				var p = new Player({tsid: 'PX', location: {tsid: 'LDUMMY'}});
+				var p = helpers.getOnlinePlayer(
+					{tsid: 'PX', location: {tsid: 'LDUMMY'}});
 				rc.cache[p.tsid] = p;  // add to RC cache so pers.get('PX') works
 				var it = Item.create('meat', 5);
 				it.tcont = p.tsid;
@@ -282,7 +285,8 @@ suite('Item', function () {
 		test('queues appropriate changes', function (done) {
 			var rc = new RC();
 			rc.run(function () {
-				var p = new Player({tsid: 'PX', location: {tsid: 'LDUMMY'}});
+				var p = helpers.getOnlinePlayer(
+					{tsid: 'PX', location: {tsid: 'LDUMMY'}});
 				rc.cache[p.tsid] = p;  // add to RC cache so pers.get('PX') works
 				var it = new Item({tsid: 'IX', class_tsid: 'meat', tcont: 'PX'});
 				it.container = p;
@@ -304,8 +308,8 @@ suite('Item', function () {
 			var rc = new RC();
 			rc.run(function () {
 				var l = Location.create(Geo.create());
-				var p = new Player({tsid: 'PX', location: l});
-				var p2 = new Player({tsid: 'PY', location: l});
+				var p = helpers.getOnlinePlayer({tsid: 'PX', location: l});
+				var p2 = helpers.getOnlinePlayer({tsid: 'PY', location: l});
 				l.players[p.tsid] = p;
 				l.players[p2.tsid] = p2;
 				rc.cache[p.tsid] = p;
@@ -352,7 +356,7 @@ suite('Item', function () {
 
 		test('sends removal changes to previous top container', function (done) {
 			var l = new Location({tsid: 'LX'}, new Geo());
-			var p = new Player({tsid: 'PX', location: l});
+			var p = helpers.getOnlinePlayer({tsid: 'PX', location: l});
 			l.players = {PX: p};
 			var b = new Bag({tsid: 'BX', container: l, tcont: l.tsid});
 			var it = new Item({tsid: 'IT', container: b, tcont: l.tsid});

--- a/test/func/model/Location.js
+++ b/test/func/model/Location.js
@@ -9,9 +9,9 @@ var Location = require('model/Location');
 var Geo = require('model/Geo');
 var Item = require('model/Item');
 var Bag = require('model/Bag');
-var Player = require('model/Player');
 var gsjsBridge = require('model/gsjsBridge');
 var utils = require('utils');
+var helpers = require('../../helpers');
 
 
 suite('Location', function () {
@@ -166,7 +166,7 @@ suite('Location', function () {
 			rc.run(function () {
 				// setup (create/initialize loc, player, bag)
 				var l = Location.create(Geo.create());
-				var p = new Player({tsid: 'PX', location: {tsid: l.tsid}});
+				var p = helpers.getOnlinePlayer({tsid: 'PX', location: {tsid: l.tsid}});
 				l.players = {PX: p};  // put player in loc (so loc changes are queued for p)
 				rc.cache[p.tsid] = p;  // required so b.tcont can be "loaded" from persistence
 				var b = new Bag({tsid: 'BX', class_tsid: 'bag_bigger_green'});

--- a/test/func/model/Player.js
+++ b/test/func/model/Player.js
@@ -10,6 +10,7 @@ var Bag = require('model/Bag');
 var pers = require('data/pers');
 var utils = require('utils');
 var pbeMock = require('../../mock/pbe');
+var helpers = require('../../helpers');
 
 
 suite('Player', function () {
@@ -153,7 +154,8 @@ suite('Player', function () {
 
 		test('works as expected (basic changeset)', function (done) {
 			new RC().run(function () {
-				var p = new Player({tsid: 'PX', location: {tsid: 'LDUMMY'}});
+				var p = helpers.getOnlinePlayer(
+					{tsid: 'PX', location: {tsid: 'LDUMMY'}});
 				var it = new Item(
 					{tsid: 'IX', class_tsid: 'meat', count: 3, tcont: 'PX'});
 				p.queueChanges(it);
@@ -171,7 +173,8 @@ suite('Player', function () {
 
 		test('works as expected (basic removal changeset)', function (done) {
 			new RC().run(function () {
-				var p = new Player({tsid: 'PX', location: {tsid: 'LDUMMY'}});
+				var p = helpers.getOnlinePlayer(
+					{tsid: 'PX', location: {tsid: 'LDUMMY'}});
 				var it = new Item(
 					{tsid: 'IX', class_tsid: 'meat', count: 3, tcont: 'PX'});
 				p.queueChanges(it, true);
@@ -184,7 +187,7 @@ suite('Player', function () {
 
 		test('works as expected (location changesets)', function (done) {
 			new RC().run(function () {
-				var p = new Player({tsid: 'PX', location: {tsid: 'LX'}});
+				var p = helpers.getOnlinePlayer({tsid: 'PX', location: {tsid: 'LX'}});
 				var it = new Item({tsid: 'IX', class_tsid: 'apple', tcont: 'LX'});
 				p.queueChanges(it);  // added to location
 				p.queueChanges(it, true);  // removed from location again
@@ -223,7 +226,6 @@ suite('Player', function () {
 					rc.cache[p.tsid] = p;
 					var it = new Item({tsid: 'IX', class_tsid: 'pi',
 						tcont: l.tsid, container: l});
-					p.addToSlot(it, 5);
 					p.session = {
 						send: function send(msg) {
 							assert.strictEqual(msg.changes.location_tsid, l.tsid);
@@ -236,6 +238,7 @@ suite('Player', function () {
 							done();
 						},
 					};
+					p.addToSlot(it, 5);
 					p.send({});
 				},
 				function (err, res) {
@@ -248,8 +251,6 @@ suite('Player', function () {
 			new RC().run(
 				function () {
 					var p = new Player();
-					p.queueAnnc({id: 'someAnnc', data: 5});
-					p.queueAnnc({mo1: 'money', mo2: 'problems'});
 					p.session = {
 						send: function send(msg) {
 							var anncs = msg.announcements;
@@ -262,6 +263,8 @@ suite('Player', function () {
 							done();
 						},
 					};
+					p.queueAnnc({id: 'someAnnc', data: 5});
+					p.queueAnnc({mo1: 'money', mo2: 'problems'});
 					var origMsg = {};
 					p.send(origMsg);
 				},

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,6 +2,7 @@
 
 var amf = require('node_amf_cc');
 var events = require('events');
+var Player = require('model/Player');
 
 
 exports.getDummySocket = function getDummySocket() {
@@ -10,6 +11,16 @@ exports.getDummySocket = function getDummySocket() {
 		ret.emit('data', data);  // simple echo
 	};
 	ret.setNoDelay = function setNoDelay() {};  // dummy
+	return ret;
+};
+
+
+exports.getOnlinePlayer = function getOnlinePlayer(data) {
+	// create a "connected" player instance with a dummy session object
+	var ret = new Player(data);
+	ret.session = {
+		send: function send() {},
+	};
 	return ret;
 };
 

--- a/test/unit/model/Location.js
+++ b/test/unit/model/Location.js
@@ -110,11 +110,15 @@ suite('Location', function () {
 
 		test('works as expected', function () {
 			var p1 = new Player();
+			p1.session = {};  // dummy
 			var p2 = new Player();
-			var l = new Location({players: [p1]}, new Geo());
+			p2.session = {};  // dummy
+			var p3 = new Player();
+			var l = new Location({players: [p1, p3]}, new Geo());
 			l.queueAnnc({gargle: 'marbles'});
 			assert.deepEqual(p1.anncs, [{gargle: 'marbles'}]);
 			assert.deepEqual(p2.anncs, [], 'not queued for p2 (not in this loc)');
+			assert.deepEqual(p3.anncs, [], 'not queued for p3 (not online/no session)');
 		});
 	});
 


### PR DESCRIPTION
when a Player object has no session associated (no connected client,
e.g. due to an unclean disconnect), changes and announcements are
never processed/sent, so don't queue them in the first place