### PR TITLE
parse slot number argument if necessary

### DIFF
--- a/src/model/Bag.js
+++ b/src/model/Bag.js
@@ -198,6 +198,7 @@ Bag.prototype.getClassItems = function getClassItems(classTsid, max) {
  *          is empty
  */
 Bag.prototype.getSlot = function getSlot(slot) {
+	slot = utils.intVal(slot);
 	for (var k in this.items) {
 		if (this.items[k].x === slot) {
 			return this.items[k];

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,6 +12,7 @@ module.exports = {
 	checkUniqueHashes: checkUniqueHashes,
 	copyProps: copyProps,
 	isInt: isInt,
+	intVal: intVal,
 	isGameObject: isGameObject,
 	isBag: isBag,
 	isPlayer: isPlayer,
@@ -122,6 +123,23 @@ function copyProps(from, to) {
  */
 function isInt(i) {
 	return i !== null && i !== '' && typeof i !== 'boolean' && i % 1 === 0;
+}
+
+
+/**
+ * Converts a string containing a numeric value to the actual
+ * corresponding number (radix 10).
+ *
+ * @param {string|number} i the string to convert (finite numbers are
+ *        also accepted and just passed through)
+ * @returns {number} the parsed numeric value
+ * @throws {AssertionError} in case the given string cannot be parsed
+ *         to a finite integer value
+ */
+function intVal(i) {
+	var ret = parseInt(i, 10);
+	assert(!isNaN(ret) && isFinite(ret), 'invalid numeric value: ' + i);
+	return ret;
 }
 
 

--- a/test/unit/model/Bag.js
+++ b/test/unit/model/Bag.js
@@ -177,4 +177,24 @@ suite('Bag', function () {
 			assert.deepEqual(b.getSlots(4), [i2, null, null, i1]);
 		});
 	});
+
+
+	suite('addToSlot', function () {
+
+		test('works with string-type slot argument', function () {
+			var i1 = new Item({tsid: 'I1'});
+			var i2 = new Item({tsid: 'I2', x: 123, y: 345});
+			var b = new Bag({tsid: 'B1', tcont: 'PDUMMY'});
+			b.capacity = 1;
+			// changeset creation not tested here:
+			i1.queueChanges = i2.queueChanges = b.queueChanges = function noop() {};
+			b.addToSlot(i1, 0);
+			var merged = b.addToSlot(i2, '0');  // GSJS actually does this :/
+			assert.strictEqual(merged, 0, 'not added to occupied slot');
+			assert.deepEqual(b.items, {I1: i1});
+			assert.strictEqual(i1.slot, 0);
+			assert.isUndefined(i2.slot);
+			assert.strictEqual(i2.x, 123);
+		});
+	});
 });

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -155,6 +155,45 @@ suite('utils', function () {
 	});
 
 
+	suite('intVal', function () {
+
+		test('works as expected', function () {
+			assert.strictEqual(utils.intVal('0'), 0);
+			assert.strictEqual(utils.intVal('123'), 123);
+			assert.strictEqual(utils.intVal(' 123'), 123);
+			assert.strictEqual(utils.intVal('0123'), 123);
+			assert.strictEqual(utils.intVal('-17'), -17);
+			assert.strictEqual(utils.intVal('1e3'), 1,
+				'does not handle exponential notation as one might expect');
+			assert.strictEqual(utils.intVal('1e-3'), 1);
+		});
+
+		test('works for number-type input, too', function () {
+			assert.strictEqual(utils.intVal(0), 0);
+			assert.strictEqual(utils.intVal(10.12), 10);
+			assert.strictEqual(utils.intVal(1e4), 10000);
+		});
+
+		test('fails with non-finite/NaN and other invalid values', function () {
+			assert.throw(function () {
+				utils.intVal('blubb');
+			}, Error);
+			assert.throw(function () {
+				utils.intVal(-1 / 0);
+			}, Error);
+			assert.throw(function () {
+				utils.intVal('');
+			}, Error);
+			assert.throw(function () {
+				utils.intVal(undefined);
+			}, Error);
+			assert.throw(function () {
+				utils.intVal(null);
+			}, Error);
+		});
+	});
+
+
 	suite('makeNonEnumerable', function () {
 
 		test('does its job', function () {


### PR DESCRIPTION
In some situations, GSJS code supplies a string-type slot argument to
inventory handling functions, which caused those functions to fail
silently and cause odd effects.

Fixes trello#85.