### PR TITLE
handle ping messages directly in GS

### DIFF
--- a/src/comm/Session.js
+++ b/src/comm/Session.js
@@ -278,6 +278,14 @@ Session.prototype.preRequestProc = function preRequestProc(req) {
 			if (this.pc) this.pc.onDisconnect();
 			this.socket.end();
 			return true;
+		case 'ping':
+			this.send({
+				msg_id: req.msg_id,
+				type: req.type,
+				success: true,
+				ts: Math.round(new Date().getTime() / 1000),
+			});
+			return true;
 		default:
 			if (!this.pc) {
 				log.info({session: this}, 'closing session after unexpected' +

--- a/test/unit/comm/Session.js
+++ b/test/unit/comm/Session.js
@@ -187,6 +187,23 @@ suite('Session', function () {
 	});
 
 
+	suite('preRequestProc', function () {
+
+		test('handles ping request', function (done) {
+			var s = getTestSession('test', getDummySocket());
+			s.send = function (msg) {
+				assert.strictEqual(msg.type, 'ping');
+				assert.strictEqual(msg.msg_id, 12);
+				assert.isTrue(msg.success);
+				assert.closeTo(msg.ts * 1000, new Date().getTime(), 1000);
+				done();
+			};
+			var res = s.preRequestProc({type: 'ping', msg_id: 12});
+			assert.isTrue(res);
+		});
+	});
+
+
 	suite('handleAmfReqError', function () {
 
 		test('sends CLOSE message', function (done) {


### PR DESCRIPTION
Handle ping messages in the game server (as opposed to deferring to
GSJS), since this seems more in line with original server behavior
(client ignores changes/announcements in ping replies, ping messages
interrupting meditation, etc)