### PR TITLE
perform persistence operations in safe order

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
 	"eqeqeq": true,
+	"esnext": true,
 	"freeze": true,
 	"globals": {
 		"log": true,

--- a/src/data/RequestContext.js
+++ b/src/data/RequestContext.js
@@ -40,7 +40,8 @@ function RequestContext(logtag, owner, session) {
 	this.session = session;
 	// request-local game object cache
 	this.cache = {};
-	// dirty object collector for persistence
+	// dirty object collectors for persistence
+	this.added = {};
 	this.dirty = {};
 	// objects scheduled for unloading after current request
 	this.unload = {};
@@ -82,16 +83,20 @@ RequestContext.prototype.run = function run(func, callback, waitPers) {
 			Fiber.current.rc = rc;
 			// call function in fiber context
 			res = func();
-			log.debug('finished %s (%s dirty)', tag, Object.keys(rc.dirty).length);
+			log.debug('finished %s (%s dirty, %s added)', tag,
+				Object.keys(rc.dirty).length, Object.keys(rc.added).length);
 		}
 		catch (err) {
-			pers.postRequestRollback(rc.dirty, tag, function done() {
+			/*jshint -W030 */  // trigger prepareStackTrace (parts of the trace might not be available outside the RC)
+			err.stack;
+			/*jshint +W030 */
+			pers.postRequestRollback(rc.dirty, rc.added, tag, function done() {
 				callback(err);
 			});
 			return;
 		}
 		// persist modified objects
-		pers.postRequestProc(rc.dirty, rc.unload, tag, function done() {
+		pers.postRequestProc(rc.dirty, rc.added, rc.unload, tag, function done() {
 			// invoke special post-persistence callback if there is one
 			if (typeof rc.postPersCallback === 'function') {
 				rc.postPersCallback();
@@ -150,10 +155,16 @@ RequestContext.logSerialize = function logSerialize(rc) {
  * finishes successfully). Can only be called from within a request
  * (see {@link RequestContext#run|run}).
  *
- * @param {GameObject} obj
+ * @param {GameObject} obj the new or updated object
+ * @param {boolean} [added] `true` if `obj` is a newly created object
  */
-RequestContext.prototype.setDirty = function setDirty(obj) {
-	this.dirty[obj.tsid] = obj;
+RequestContext.prototype.setDirty = function setDirty(obj, added) {
+	if (added) {
+		this.added[obj.tsid] = obj;
+	}
+	else if (!(obj.tsid in this.added)) {
+		this.dirty[obj.tsid] = obj;
+	}
 };
 
 

--- a/test/func/model/Location.js
+++ b/test/func/model/Location.js
@@ -87,8 +87,8 @@ suite('Location', function () {
 				assert.strictEqual(l.geometry.tsid, 'GX',
 					'TSID changed back according to Location TSID');
 				// check that it will be persisted
-				assert.deepEqual(Object.keys(rc.dirty), ['GX']);
-				var newG = rc.dirty.GX;
+				assert.deepEqual(Object.keys(rc.added), ['GX']);
+				var newG = rc.added.GX;
 				assert.instanceOf(newG.__proxyTarget, Geo);
 				assert.strictEqual(newG.tsid, 'GX');
 				assert.strictEqual(newG.something, 'foomp');

--- a/test/mock/pers.js
+++ b/test/mock/pers.js
@@ -15,12 +15,14 @@ module.exports = {
 
 var cache = {};
 var dlist = {};
+var alist = {};
 var ulist = {};
 
 
 function reset() {
 	cache = {};
 	dlist = {};
+	alist = {};
 	ulist = {};
 }
 
@@ -49,14 +51,15 @@ function preAdd() {
 }
 
 
-function postRequestProc(dl, ul, logmsg, postPersCallback) {
+function postRequestProc(dl, al, ul, logmsg, postPersCallback) {
 	dlist = dl;
+	alist = al;
 	ulist = ul;
 	if (postPersCallback) postPersCallback();
 }
 
 
-function postRequestRollback(dl, logmsg, callback) {
+function postRequestRollback(dl, al, logmsg, callback) {
 	ulist = dl;  // dirty objects are unloaded here
 	if (callback) callback();
 }

--- a/test/unit/data/RequestContext.js
+++ b/test/unit/data/RequestContext.js
@@ -72,8 +72,8 @@ suite('RequestContext', function () {
 		test('waits for persistence operation callback if desired', function (done) {
 			var persDone = false;
 			RC.__set__('pers', {
-				postRequestProc: function postRequestProc(dlist, ulist, logtag,
-					callback) {
+				postRequestProc: function postRequestProc(dlist, alist, ulist,
+					logtag, callback) {
 					// simulate an async persistence operation that takes 20ms
 					setTimeout(function () {
 						persDone = true;


### PR DESCRIPTION
Make sure post-request persistence operations are performed in a way that
prevents invalid object references (first add new objects, then modify
existing ones, then remove deleted).