### PR TITLE
actually start interval in apiSetInterval

### DIFF
--- a/src/model/GameObjectApi.js
+++ b/src/model/GameObjectApi.js
@@ -104,7 +104,7 @@ GameObjectApi.prototype.apiTimerExists = function apiTimerExists(fname) {
  */
 GameObjectApi.prototype.apiSetInterval = function apiSetInterval(fname, period) {
 	log.debug('%s.apiSetInterval(%s, %s)', this, fname, period);
-	this.setGsTimer({fname: fname, delay: period * 60000});
+	this.setGsTimer({fname: fname, interval: true, delay: period * 60000});
 };
 
 


### PR DESCRIPTION
`apiSetInterval` needs to specify the `interval` option, otherwise it
just creates a one-off timer (this caused newly created trants not to
grow/decay).