### PR TITLE
reflect label changes of wrapped objects in proxy

### DIFF
--- a/src/data/objrefProxy.js
+++ b/src/data/objrefProxy.js
@@ -97,6 +97,10 @@ function makeProxy(objref) {
 		},
 		// other operations: resolve reference and perform operation on actual object
 		set: function set(target, name, val, receiver) {
+			if (name === 'label' && val !== undefined) {
+				// special case: sync label property in proxy
+				target[name] = val;
+			}
 			resolve(target)[name] = val;
 		},
 		has: function has(target, name) {

--- a/test/unit/data/objrefProxy.js
+++ b/test/unit/data/objrefProxy.js
@@ -298,5 +298,13 @@ suite('objrefProxy', function () {
 			assert.isNull(orproxy.wrap(null));
 			assert.isUndefined(orproxy.wrap(undefined));
 		});
+
+		test('label changes in wrapped objects are reflected in proxy', function () {
+			var go = new GameObject();
+			persMock.add(go);
+			var wrapped = orproxy.wrap(go);
+			wrapped.label = 'Lemmiwinks';
+			assert.strictEqual(wrapped.label, 'Lemmiwinks');
+		});
 	});
 });


### PR DESCRIPTION
When game objects are created without an initial label, and the label is
later adjusted by setting the property, this change needs to be reflected
in the objref proxy wrapper.