### PR TITLE
don't send changes for hidden items

### DIFF
--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -193,13 +193,13 @@ Item.prototype.setContainer = function setContainer(cont, x, y, hidden) {
 		}
 		cont[hidden ? 'hiddenItems' : 'items'][this.tsid] = this;
 	}
-	this.is_hidden = !!hidden;
 	// queue removal change if top container changed
 	if (tcont !== this.tcont) {
 		this.queueChanges(true);
 	}
 	// assign to new container and queue addition/update changes
 	this.tcont = tcont;
+	this.is_hidden = !!hidden;
 	this.setXY(x, y);
 	this.updatePath();
 	this.queueChanges();
@@ -282,7 +282,7 @@ Item.prototype.getPosObject = function getPosObject() {
  *        (only coordinates and state, for NPC movement)
  */
 Item.prototype.queueChanges = function queueChanges(removed, compact) {
-	if (this.tcont) {
+	if (this.tcont && !this.is_hidden) {
 		pers.get(this.tcont).queueChanges(this, removed, compact);
 	}
 };

--- a/test/func/model/Item.js
+++ b/test/func/model/Item.js
@@ -331,6 +331,31 @@ suite('Item', function () {
 			}, done);
 		});
 
+		test('does not queue changes for hidden items', function (done) {
+			var rc = new RC();
+			rc.run(function () {
+				// setup
+				var l = Location.create(Geo.create());
+				var p1 = helpers.getOnlinePlayer({tsid: 'P1', location: l});
+				rc.cache[p1.tsid] = p1;
+				var p2 = helpers.getOnlinePlayer({tsid: 'P2', location: l});
+				rc.cache[p2.tsid] = p2;
+				// test adding hidden item (regular case)
+				var i1 = new Item({tsid: 'I1'});
+				i1.setContainer(p1, 1, 2, true);
+				assert.lengthOf(p1.changes, 0, 'no changes queued for hidden item');
+				// test hiding previously non-hidden item
+				var i2 = new Item({tsid: 'I2'});
+				i2.setContainer(p2, 1, 2);
+				p2.changes = [];  // reset (just testing what comes next)
+				i2.setContainer(p1, 1, 2, true);
+				assert.lengthOf(p2.changes, 1,
+					'change queued for removal of not yet hidden item');
+				assert.lengthOf(p1.changes, 0,
+					'no changes queued for now hidden item');
+			}, done);
+		});
+
 		test('does not queue removal change when moving within same container',
 			function (done) {
 			var rc = new RC();


### PR DESCRIPTION
Don't consider hidden items (furniture, escrow, trophy bags etc.) when
generating item changes, otherwise these may show up in the client as
white slots or stoot heads in the player inventory.