### PR TITLE
prevent RPC forwarding cycles

### DIFF
--- a/src/data/rpc.js
+++ b/src/data/rpc.js
@@ -323,6 +323,9 @@ function handleRequest(callerId, objOrTsid, fname, args, callback) {
 				throw new RpcError(util.format('no such function: %s.%s',
 					objOrTsid, fname));
 			}
+			if (obj.__isRP) {
+				throw new RpcError('redirect loop detected: ' + objOrTsid);
+			}
 			var ret = obj[fname].apply(obj, args);
 			// convert <undefined> result to <null> so RPC lib produces a valid
 			// response (it just omits the <result> property otherwise)


### PR DESCRIPTION
Prevent sending RPC requests back and forth indefinitely between
GS worker processes in split-brain/inconsistent state situations.

Fixes trello#108 https://trello.com/c/nRBXdPGn