### PR TITLE
don't refuse forwarding external RPC calls

### DIFF
--- a/src/data/rpc.js
+++ b/src/data/rpc.js
@@ -358,9 +358,6 @@ function handleRequest(callerId, objOrTsid, fname, args, callback) {
 				throw new RpcError(util.format('no such function: %s.%s',
 					objOrTsid, fname));
 			}
-			if (obj.__isRP) {
-				throw new RpcError('redirect loop detected: ' + objOrTsid);
-			}
 			var ret = obj[fname].apply(obj, args);
 			// convert <undefined> result to <null> so RPC lib produces a valid
 			// response (it just omits the <result> property otherwise)


### PR DESCRIPTION
Revert part of 67aa101 because it breaks HTTP API and webapp RPC requests
(they always send RPCs to the first worker, who may then need to forward
the call to another instance). To make this work right, we would need
to distinguish between calls coming from other GS workers and calls from
"external" sources.