### PR TITLE
replace non-persistable property values with null

### DIFF
--- a/src/data/pbe/rethink.js
+++ b/src/data/pbe/rethink.js
@@ -17,6 +17,7 @@ module.exports = {
 
 var rdb = require('rethinkdb');
 var wait = require('wait.for');
+var utils = require('utils');
 
 
 var cfg;
@@ -145,6 +146,7 @@ function write(obj, queryOpts, callback) {
 		callback = queryOpts;
 		queryOpts = null;
 	}
+	utils.typeGuard(obj, true);
 	var query = rdb.table(getTable(obj)).insert(obj, {conflict: 'replace'});
 	runQuery(query, queryOpts, callback);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,6 +31,7 @@ module.exports = {
 	gameObjArgToList: gameObjArgToList,
 	playersArgToList: playersArgToList,
 	pointOnPlat: pointOnPlat,
+	typeGuard: typeGuard,
 };
 
 
@@ -453,4 +454,30 @@ function pointOnPlat(plat, x) {
 		ret = {x: x, y: Math.floor(y)};
 	}
 	return ret;
+}
+
+
+/**
+ * Recursively removes properties with "non JSON safe" values (`NaN`,
+ * `Infinity`, `undefined`) from an object. Works **in place**, i.e.
+ * the given object is modified.
+ *
+ * @param {object} obj the object to cleanse
+ * @param {boolean} [nullify] when `true`, sets properties with unsafe
+ *        values to `null` instead of removing them
+ * @returns {object} the modified input object
+ */
+function typeGuard(obj, nullify) {
+	assert(typeof obj === 'object' && obj !== null);
+	for (var k in obj) {
+		var v = obj[k];
+		if (typeof v === 'object' && v !== null) {
+			typeGuard(v, nullify);
+		}
+		else if (v === undefined || typeof v === 'number' && !isFinite(v)) {
+			if (nullify) obj[k] = null;
+			else delete obj[k];
+		}
+	}
+	return obj;
 }

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -500,4 +500,34 @@ suite('utils', function () {
 		});
 	});
 
+
+	suite('typeGuard', function () {
+
+		test('works as expected', function () {
+			assert.deepEqual(utils.typeGuard({}), {});
+			assert.deepEqual(utils.typeGuard([]), []);
+			assert.deepEqual(utils.typeGuard({
+				a: 'a', b: 1, c: null,
+				d: undefined, e: -Infinity, f: NaN,
+			}), {
+				a: 'a', b: 1, c: null,
+			});
+			assert.deepEqual(utils.typeGuard({
+				a: {b: 1, c: {x: undefined, y: 1}, d: ['z', [NaN]]},
+			}), {
+				a: {b: 1, c: {y: 1}, d: ['z', []]},
+			});
+			assert.deepEqual(utils.typeGuard({
+				a: {b: 1, c: {x: undefined, y: 1}, d: ['z', [NaN]]},
+			}, true), {
+				a: {b: 1, c: {x: null, y: 1}, d: ['z', [null]]},
+			});
+		});
+
+		test('modifies the given object in place', function () {
+			var o = {a: 'a', b: 1, c: null, d: undefined, e: -Infinity, f: NaN};
+			assert.deepEqual(utils.typeGuard(o), {a: 'a', b: 1, c: null});
+			assert.deepEqual(o, {a: 'a', b: 1, c: null});
+		});
+	});
 });


### PR DESCRIPTION
Set game object properties with values that cannot be persisted in
RethinkDB (NaN, Infinity, undefined) to null.