### PR TITLE
make OrderedHash enumerate properties in natural order

### DIFF
--- a/src/model/OrderedHash.js
+++ b/src/model/OrderedHash.js
@@ -3,6 +3,7 @@
 module.exports = OrderedHash;
 
 
+require('harmony-reflect');
 var utils = require('utils');
 
 
@@ -10,29 +11,65 @@ var utils = require('utils');
  * A class that provides sorted map functionality in JS. Entries are
  * sorted using natural order of keys.
  *
- * For the sake of simplicity, the special accessor functions {@link
- * OrderedHash#first|first} and {@link OrderedHash#last|last} depend on
- * sorting the key list **on each call**.
- * Hence, this class is obviously **not** suited for working with big
- * collections.
+ * For the sake of simplicity, property keys are sorted on read access
+ * (resp. on enumeration); this class is obviously **not** well suited
+ * for big collections with few writes and many reads.
  *
  * @param {object} [data] optional initial content (properties are
  *        shallow-copied into the hash)
  * @constructor
  */
 function OrderedHash(data) {
+	// wrap the actual class in a proxy that makes sure for...in loops
+	// loop over the properties in natural order of their keys
+	return new Proxy(new OrderedHashAux(data), {
+		enumerate: function enumerate(target) {
+			var sortedKeys = target.sortedKeys();
+			var l = sortedKeys.length;
+			var i = 0;
+			return {
+				next: function next() {
+					if (i === l) return {done: true};
+					return {
+						done: false,
+						value: sortedKeys[i++],
+					};
+				},
+			};
+		},
+		ownKeys: function ownKeys(target) {
+			return target.sortedKeys();
+		},
+		get: function get(target, name, receiver) {
+			if (name === 'toJSON') {
+				// required to prevent weird context-less "illegal access"
+				// errors when stringifying proxied objects (or objects with
+				// proxied children)
+				// see: https://github.com/tvcutsem/harmony-reflect/issues/38
+				return function toJSON() {
+					return target;
+				};
+			}
+			return target[name];
+		},
+	});
+}
+
+
+function OrderedHashAux(data) {
 	utils.copyProps(data, this);
 }
 
 
 /**
- * Helper function for {@link OrderedHash#first|first} and {@link
- * OrderedHash#last|last}.
+ * Helper function for {@link OrderedHashAux#first|first} and {@link
+ * OrderedHashAux#last|last}.
  * @private
  */
-OrderedHash.prototype.sortedKeys = function sortedKeys() {
+OrderedHashAux.prototype.sortedKeys = function sortedKeys() {
 	return Object.keys(this).sort();
 };
+utils.makeNonEnumerable(OrderedHashAux.prototype, 'sortedKeys');
 
 
 /**
@@ -41,9 +78,10 @@ OrderedHash.prototype.sortedKeys = function sortedKeys() {
  *
  * @returns {*} first value in the hash
  */
-OrderedHash.prototype.first = function first() {
+OrderedHashAux.prototype.first = function first() {
 	return this[this.sortedKeys()[0]];
 };
+utils.makeNonEnumerable(OrderedHashAux.prototype, 'first');
 
 
 /**
@@ -52,9 +90,10 @@ OrderedHash.prototype.first = function first() {
  *
  * @returns {*} last value in the hash
  */
-OrderedHash.prototype.last = function last() {
+OrderedHashAux.prototype.last = function last() {
 	return this[this.sortedKeys().slice(-1)];
 };
+utils.makeNonEnumerable(OrderedHashAux.prototype, 'last');
 
 
 /**
@@ -62,18 +101,20 @@ OrderedHash.prototype.last = function last() {
  *
  * @returns {number} number of key/value pairs stored in the hash
  */
-OrderedHash.prototype.length = function length() {
+OrderedHashAux.prototype.length = function length() {
 	return Object.keys(this).length;
 };
+utils.makeNonEnumerable(OrderedHashAux.prototype, 'length');
 
 
 /**
  * Clears the hash by removing all non-function direct properties.
  */
-OrderedHash.prototype.clear = function clear() {
+OrderedHashAux.prototype.clear = function clear() {
 	for (var prop in this) {
 		if (this.hasOwnProperty(prop) && typeof this[prop] !== 'function') {
 			delete this[prop];
 		}
 	}
 };
+utils.makeNonEnumerable(OrderedHashAux.prototype, 'clear');

--- a/test/unit/model/Item.js
+++ b/test/unit/model/Item.js
@@ -6,7 +6,6 @@ var Bag = require('model/Bag');
 var Player = require('model/Player');
 var Geo = require('model/Geo');
 var Location = require('model/Location');
-var OrderedHash = require('model/OrderedHash');
 
 
 suite('Item', function () {
@@ -30,7 +29,6 @@ suite('Item', function () {
 
 		test('initializes message_queue as OrderedHash', function () {
 			var i = new Item({message_queue: {b: 'b', a: 'a'}});
-			assert.instanceOf(i.message_queue, OrderedHash);
 			assert.strictEqual(i.message_queue.first(), 'a');
 		});
 	});

--- a/test/unit/model/OrderedHash.js
+++ b/test/unit/model/OrderedHash.js
@@ -10,7 +10,6 @@ suite('OrderedHash', function () {
 		test('creates OrderedHash', function () {
 			var o = {x: 'x', y: 'y', z: 'z'};
 			var oh = new OrderedHash(o);
-			assert.instanceOf(oh, OrderedHash);
 			assert.strictEqual(oh.x, 'x');
 			oh.q = 'q';
 			assert.notProperty(o, 'q', 'new properties not added to source data object');
@@ -25,6 +24,25 @@ suite('OrderedHash', function () {
 			var oh = new OrderedHash({x: 'x', yz: {y: 'y', z: 'z'}});
 			assert.strictEqual(JSON.stringify(oh),
 				'{"x":"x","yz":{"y":"y","z":"z"}}');
+		});
+
+		test('makes property enumeration iterate over keys in natural order',
+			function () {
+			var oh = new OrderedHash({z: 'z', a: 'a'});
+			var keys = [];
+			for (var k in oh) {
+				keys.push(k);
+			}
+			assert.deepEqual(keys, ['a', 'z']);
+			assert.deepEqual(Object.keys(oh), ['a', 'z']);
+			oh.burp = 'b';
+			oh['234'] = '123';
+			keys = [];
+			for (var j in oh) {
+				keys.push(j);
+			}
+			assert.deepEqual(keys, ['234', 'a', 'burp', 'z']);
+			assert.deepEqual(Object.keys(oh), ['234', 'a', 'burp', 'z']);
 		});
 	});
 


### PR DESCRIPTION
GSJS code expects for...in loops on OrderedHash instances to iterate
over their properties in natural order.