### PR TITLE
do not modify log message payload object

### DIFF
--- a/src/logging.js
+++ b/src/logging.js
@@ -16,10 +16,12 @@ module.exports = {
 };
 
 
+require('harmony-reflect');
 var assert = require('assert');
 var bunyan = require('bunyan');
 var config = require('config');
 var fs = require('fs');
+var lodash = require('lodash');
 var path = require('path');
 var RC = require('data/RequestContext');
 var Session = require('comm/Session');
@@ -170,6 +172,9 @@ function wrapLogEmitter(emitter, metric) {
 			metrics.increment(metric);
 		}
 		// add 'rc' and 'session' fields if available
+		if (typeof arguments[0] === 'object' && arguments[0] !== null) {
+			arguments[0] = lodash.clone(arguments[0]);
+		}
 		var rc = RC.getContext(true);
 		if (rc) {
 			addField(arguments, 'rc', rc);

--- a/test/func/logging.js
+++ b/test/func/logging.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var rewire = require('rewire');
+var logging = rewire('logging');
+var RC = require('data/RequestContext');
+
+
+suite('logging', function () {
+
+	var origLogger;
+
+	setup(function () {
+		origLogger = logging.__get__('logger');
+		logging.__set__('logger', log);
+	});
+
+	teardown(function () {
+		logging.__set__('logger', origLogger);
+	});
+
+
+	suite('custom log emitter', function () {
+
+		test('does not modify passed data object', function (done) {
+			var data = {some: 'data'};
+			var emitter = function () {
+				if (!arguments.length) return true;  // just to fool log level test
+				assert.deepEqual(data, {some: 'data'});
+				done();
+			};
+			var wrapLogEmitter = logging.__get__('wrapLogEmitter');
+			var wrappedEmitter = wrapLogEmitter(emitter);
+			new RC().run(function () {
+				wrappedEmitter(data, 'foozux');
+			}, function cb(err) {
+				if (err) return done(err);
+			});
+		});
+	});
+});


### PR DESCRIPTION
When supplying a data object to a logging function (such as `log.info`),
that object should not be modified in any way.
See https://trello.com/c/DFakmeeZ