### PR TITLE
disable round-robin cluster scheduling

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -57,6 +57,7 @@ function main() {
 
 function runMaster() {
 	log.info('starting cluster master %s', config.getGsid());
+	cluster.schedulingPolicy = cluster.SCHED_NONE;
 	config.forEachLocalGS(startWorker);
 	policyServer.start();
 	process.on('SIGINT', shutdown);


### PR DESCRIPTION
The cluster master process is occasionally crashing due to internal
messaging problems. According to an open node.js issue, disabling
round-robin scheduling might help (and the way we are using the cluster
module, RR does not provide any benefit anyway).
See https://trello.com/c/JUVeIsdu