### PR TITLE
Ensure timer setup changes are persisted

### DIFF
--- a/src/data/RequestContext.js
+++ b/src/data/RequestContext.js
@@ -150,6 +150,19 @@ RequestContext.logSerialize = function logSerialize(rc) {
 
 
 /**
+ * Flags the given (existing/not newly created) game object as dirty, causing it
+ * to be written to persistent storage at the end of the current request. Does
+ * nothing when called without an active request context.
+ *
+ * @param {GameObject} obj the modified game object
+ */
+RequestContext.setDirty = function setDirty(obj) {
+	var rc = RequestContext.getContext(true);
+	if (rc) rc.setDirty(obj);
+};
+
+
+/**
  * Flags the given game object as dirty, causing it to be written to
  * persistent storage at the end of the current request (if the request
  * finishes successfully). Can only be called from within a request

--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -209,6 +209,8 @@ GameObject.prototype.setGsTimer = function setGsTimer(options) {
 		start: new Date().getTime(),
 		options: options,
 	};
+	// make sure update timer setup is persisted (gsTimers is non-enumerable)
+	RC.setDirty(this);
 };
 
 
@@ -258,6 +260,8 @@ GameObject.prototype.scheduleTimer = function scheduleTimer(options, key) {
 						delete self.gsTimers[key];
 						self.setGsTimer(options);
 					}
+					// make sure update timer setup is persisted
+					rc.setDirty(self);
 				},
 				function callback(e) {
 					if (e) {
@@ -380,12 +384,12 @@ GameObject.prototype.resumeGsTimers = function resumeGsTimers() {
 /**
  * Cancels a scheduled timer call, resp. clears an interval call.
  *
- * @param {string} fname name of the method whose tiner/interval call
+ * @param {string} fname name of the method whose timer/interval call
  *        should be canceled
  * @param {boolean} [interval] if `true`, cancels an interval call for
  *        the given function, otherwise a timer
  * @returns {boolean} `true` if a scheduled timer/interval was actually
- *          cancelled
+ *          canceled
  */
 GameObject.prototype.cancelGsTimer = function cancelGsTimer(fname, interval) {
 	var ret = false;
@@ -398,6 +402,8 @@ GameObject.prototype.cancelGsTimer = function cancelGsTimer(fname, interval) {
 			ret = true;
 		}
 		delete this.gsTimers[fname];
+		// make sure update timer setup is persisted (gsTimers is non-enumerable)
+		RC.setDirty(this);
 	}
 	return ret;
 };


### PR DESCRIPTION
Make sure added or removed timers/intervals on game objects are persisted.
This should fix these issues (completely or at least partially):
trello#105 https://trello.com/c/AmXgDMlm
trello#126 https://trello.com/c/hPrY4WDF
trello#127 https://trello.com/c/QUIfoIz2