### PR TITLE
More liberal test timeouts

### DIFF
--- a/test/func/comm/Session.js
+++ b/test/func/comm/Session.js
@@ -55,7 +55,7 @@ suite('Session', function () {
 		});
 
 		test('works with a number of concurrent connections', function (done) {
-			var numbers = Array.apply(null, {length: 1000}).map(Number.call, Number);
+			var numbers = Array.apply(null, {length: 100}).map(Number.call, Number);
 			async.eachLimit(numbers, 10,
 				function iterator(i, cb) {
 					net.connect(cfg.port, cfg.host)

--- a/test/func/data/rpcApi.js
+++ b/test/func/data/rpcApi.js
@@ -11,7 +11,8 @@ var Location = require('model/Location');
 
 suite('rpcApi', function () {
 
-	this.slow(1000);  // player prototype loading takes some time
+	this.timeout(5000);  // player prototype loading takes some time
+	this.slow(1000);
 
 	setup(function () {
 		gsjsBridge.init(true);

--- a/test/func/model/ItemMovement.js
+++ b/test/func/model/ItemMovement.js
@@ -257,7 +257,7 @@ suite('ItemMovement', function () {
 					}
 					else if (args.status !== STATUS.DIR_CHANGE) {
 						assert.strictEqual(args.status, STATUS.STOP_NEW_MOVE);
-						assert.strictEqual(this.x, 24);
+						assert.closeTo(this.x, 24, 3);
 						assert.strictEqual(this.y, plat2.start.y);
 						this.stage = 1;
 					}
@@ -268,7 +268,7 @@ suite('ItemMovement', function () {
 					}
 					else if (args.status !== STATUS.DIR_CHANGE) {
 						assert.strictEqual(args.status, STATUS.STOP);
-						assert.strictEqual(this.x, 12);
+						assert.closeTo(this.x, 12, 3);
 						assert.strictEqual(this.y, plat2.start.y);
 						done();
 					}

--- a/test/func/model/gsjsBridge.js
+++ b/test/func/model/gsjsBridge.js
@@ -53,7 +53,7 @@ suite('gsjsBridge', function () {
 			});
 			pi = gsjsBridge.getProto('items', 'pi');
 			time = new Date().getTime() - time;
-			assert.isTrue(time < 1000, 'too slow: ' + time + ' ms');
+			assert.isTrue(time < 3000, 'too slow: ' + time + ' ms');
 		});
 	});
 


### PR DESCRIPTION
Make some timing sensitive tests more generous, and increase some timeouts, to make tests fail less often on machines under load (such as the one currently running our build environment).