### PR TITLE
Improvement for Trello #99 and Trello #133

### DIFF
--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -57,7 +57,13 @@ function Item(data) {
 	if (this.x === undefined) this.x = 0;
 	if (this.y === undefined) this.y = 0;
 	// for NPC Movement
-	utils.addNonEnumerable(this, 'gsMovement', null);
+	if (this.gsMovement) {
+		this.gsMovement = new ItemMovement(this);
+		utils.makeNonEnumerable(this, 'gsMovement');
+	}
+	else {
+		utils.addNonEnumerable(this, 'gsMovement', null);
+	}
 	if (!utils.isInt(this.count)) this.count = 1;
 	// add some non-enumerable properties (used internally or by GSJS)
 	utils.addNonEnumerable(this, 'collDet', false);
@@ -80,6 +86,9 @@ utils.copyProps(require('model/ItemApi').prototype, Item.prototype);
 Item.prototype.gsOnLoad = function gsOnLoad() {
 	this.updatePath();
 	Item.super_.prototype.gsOnLoad.call(this);
+	if (this.gsMovement) {
+		this.gsMovement.moveStep();
+	}
 };
 
 
@@ -558,4 +567,18 @@ Item.prototype.getClosestItem = function getClosestItem(filter, options) {
 		return this.container.getClosestItem(this.x, this.y, filter, options, this);
 	}
 	return null;
+};
+
+/**
+ * Creates a processed shallow copy of this location, prepared for
+ * serialization.
+ *
+ * @see {@link GameObject#serialize|GameObject.serialize}
+ */
+Item.prototype.serialize = function serialize() {
+	var ret = Item.super_.prototype.serialize.call(this);
+	if (this.gsMovement) {
+		ret.gsMovement =  this.gsMovement.serialize();
+	}
+	return ret;
 };

--- a/src/model/ItemMovement.js
+++ b/src/model/ItemMovement.js
@@ -52,6 +52,13 @@ var FLOCK_REPEL_DIST_SQUARED = 100 * 100;
  */
 function ItemMovement(item) {
 	this.item = item;
+	if (item.gsMovement) {
+		var keys = Object.keys(item.gsMovement);
+		for (var i = 0; i < keys.length; i++) {
+			var k = keys[i];
+			this[k] = item.gsMovement[k];
+		}
+	}
 }
 
 
@@ -942,4 +949,25 @@ ItemMovement.prototype.startMove = function startMove(transport, dest, options) 
 		return false;
 	}
 	return true;
+};
+
+/**
+ * Creates a processed shallow copy of this location, prepared for
+ * serialization.
+ *
+ * @see {@link GameObject#serialize|GameObject.serialize}
+ */
+ItemMovement.prototype.serialize = function serialize() {
+	var ret = {};
+	var keys = Object.keys(this);  // Object.keys only includes own properties
+	for (var i = 0; i < keys.length; i++) {
+		var k = keys[i];
+		if (k[0] !== '!') {
+			var val = this[k];
+			if (typeof val !== 'function') {
+				ret[k] = val;
+			}
+		}
+	}
+	return ret;
 };


### PR DESCRIPTION
This greatly improves NPC behavior in regard to when a street is
saved to persistant storage and loaded. Things that are moveing
should restart their path.

This may not be a full fix for trello card #99  and card #133 but
it greatly improves the behavior.