### PR TITLE
NPC movement related bugfixes

### DIFF
--- a/src/data/rpc.js
+++ b/src/data/rpc.js
@@ -434,7 +434,12 @@ function objectRequest(callerId, tsid, tag, fname, args, callback) {
 		function cb(err, obj) {
 			if (err) {
 				log.error(err, 'error loading %s for RPC', tsid);
-				return;
+				return callback(err);
+			}
+			if (obj.__isRP) {
+				var msg = 'RPC for object not handled by this GS: ' + tsid;
+				log.error(msg);
+				return callback(new Error(msg));
 			}
 			handleRequest(callerId, obj, tag, fname, args, callback);
 		}

--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -522,7 +522,9 @@ Item.prototype.gsStartMoving = function gsStartMoving(transport, dest, options) 
  * Stops item movement.
  */
 Item.prototype.gsStopMoving = function gsStopMoving() {
-	if (this.gsMovement && this.gsMovement.isMoving()) this.gsMovement.stopMove();
+	if (this.gsMovement && this.gsMovement.isMoving() || arguments.length) {
+		this.gsMovement.stopMove.apply(this.gsMovement, arguments);
+	}
 };
 
 

--- a/src/model/ItemMovement.js
+++ b/src/model/ItemMovement.js
@@ -793,7 +793,8 @@ ItemMovement.prototype.moveStep = function moveStep() {
 		}
 	}
 	else if (nextStep && nextStep.forceStop) {
-		return this.stopMove(nextStep.forceStop, true);
+		return this.item.setGsTimer({fname: 'gsStopMoving', delay: 1,
+			internal: true, args: [nextStep.forceStop, true]});
 	}
 	else {
 		// fallback (transport method failed to process path segment properly)
@@ -804,7 +805,8 @@ ItemMovement.prototype.moveStep = function moveStep() {
 	if (this.path.length === 0) {
 		var status = MOVE_CB_STATUS.ARRIVED;
 		if (nextStep && nextStep.status) status = nextStep.status;
-		return this.stopMove(status, true);
+		return this.item.setGsTimer({fname: 'gsStopMoving', delay: 1,
+			internal: true, args: [status, true]});
 	}
 	// Set the timer for the next movement step
 	this.item.setGsTimer({fname: 'movementTimer', delay: 333, internal: true});

--- a/test/func/model/ItemMovement.js
+++ b/test/func/model/ItemMovement.js
@@ -74,8 +74,8 @@ function addToTestLoc(it, x, y, geo) {
 
 suite('ItemMovement', function () {
 
-	this.timeout(10000);
-	this.slow(10000);
+	this.timeout(5000);
+	this.slow(5000);
 
 	setup(function () {
 		RQ.init();
@@ -88,7 +88,7 @@ suite('ItemMovement', function () {
 
 	suite('platform walking movement', function () {
 
-		test('does not start if the item is already at the given destionation',
+		test('does not start if the item is already at the given destination',
 			function (done) {
 			var i1 = newItem({tsid: 'I1', npc_walk_speed: 10});
 			i1.doneMoving = function doneMoving(args) {

--- a/test/unit/model/GameObject.js
+++ b/test/unit/model/GameObject.js
@@ -178,7 +178,7 @@ suite('GameObject', function () {
 				assert.notProperty(go.gsTimers, 'key', 'gsTimers entry removed');
 				done();
 			};
-			go.gsTimers.key = 'dummy';  // dummy gsTimers entry, just to check whether it is removed
+			go.gsTimers.key = {};  // dummy gsTimers entry, just to check whether it is removed
 			go.scheduleTimer({fname: 'foo', args: [3], delay: 30}, 'key');
 		});
 


### PR DESCRIPTION
* stop NPC movement asynchronously to prevent infinite recursion
  (see comment on https://trello.com/c/LnqVJcXV)
* cancel timer calls that are already in a request queue
  (see https://trello.com/c/KeHx7Fdb)
* prevent infinite RPC cycles