### PR TITLE
Set instance_of if copied location is an instance

### DIFF
--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -157,6 +157,9 @@ Location.copy = function copy(src, options) {
 		hubid: options.hubId,
 		is_instance: options.isInstance,
 	});
+	if (options.isInstance) {
+		ret.instance_of = src.tsid;
+	}
 	ret.copyProps(src, ['class_tsid', 'label', 'moteid', 'hubid', 'instance_me',
 		'is_instance', 'instances', 'players', 'items']);
 	for (var k in src.items) {


### PR DESCRIPTION
This is required for multi-user instances, otherwise we end up creating
a new instance for every player that joins a game. This also might fix a
few other instance related bugs that have not shown up in gameplay yet.