### PR TITLE
Only call onPlayerReconnect on reconnect

### DIFF
--- a/src/comm/Session.js
+++ b/src/comm/Session.js
@@ -335,10 +335,12 @@ Session.prototype.postRequestProc = function postRequestProc(req) {
 			break;
 		case 'relogin_end':
 			this.pc.location.gsOnPlayerEnter(this.pc);
-			// call Location.onPlayerReconnect event (necessary to make client
-			// hide hidden decos after reconnecting; relogin_start is too early
-			// for this)
-			this.pc.location.onPlayerReconnect(this.pc);
+			if (req.relogin_type === 'relogin') {
+				// call Location.onPlayerReconnect event (necessary to make client
+				// hide hidden decos after reconnecting; relogin_start is too early
+				// for this)
+				this.pc.location.onPlayerReconnect(this.pc);
+			}
 			this.flushPreLoginBuffer();
 			break;
 		case 'signpost_move_end':


### PR DESCRIPTION
Calling onPlayerReconnect in other cases results in bugs, so we should only call it when the player is reconnecting from a disconnect.

Fixes https://trello.com/c/otKiRtAV and possibly https://trello.com/c/zZxZray0