### PR TITLE
Delete old multi timer when resuming gs timers

### DIFF
--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -433,6 +433,10 @@ GameObject.prototype.resumeGsTimers = function resumeGsTimers() {
 				this.setGsTimer(intStartOpts);
 			}
 		}
+		if (entry.options.multi) {
+			// as we have made a new multi timer in setGsTimer, delete the old one
+			delete this.gsTimers[key];
+		}
 	}
 };
 

--- a/test/unit/model/GameObject.js
+++ b/test/unit/model/GameObject.js
@@ -478,6 +478,21 @@ suite('GameObject', function () {
 			resumeFinished = true;
 			assert.strictEqual(count, 0);
 		});
+		
+		test('removes old multi timer on catch-up', function (done) {
+			var go = new GameObject();
+			go.gsTimers = {
+				one: {
+					options: {fname: 'foo', delay: 30, multi: true},
+					start: new Date().getTime() - 80,
+				},
+			};
+			go.foo = function foo() {};
+			go.resumeGsTimers();
+			assert.strictEqual(Object.keys(go.gsTimers).length, 1, 
+				'old multi-timer reference was not removed');
+			done();
+		});
 	});
 
 


### PR DESCRIPTION
As setGsTimer creates a new timer, we need to delete the old one when resuming.

Fixes https://trello.com/c/Vp3AiN5N