### PR TITLE
Do not unload a location while something is making

### DIFF
--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -274,6 +274,10 @@ Location.prototype.checkUnload = function checkUnload() {
 			log.debug('not unloading %s, %s is still growing here', this, it);
 			return;
 		}
+		if (it.is_running) {
+			log.debug('not unloading %s, %s is still making here', this, it);
+			return;
+		}
 	}
 	// still here? go ahead, then
 	var self = this;


### PR DESCRIPTION
* When we start making something with a machine, the item we are making
is set on the player in making_queue. If the location is unloaded before
we finish, the contents are not set and lead to the machine becoming
unusable.

Like https://github.com/ElevenGiants/eleven-server/commit/e1fdec19a69b52d34194cf2d1263bb4b223f1566 this is pretty crude, but it fixes the bug.

Fixes https://trello.com/c/6IhjkaKJ