### PR TITLE
Add stack merging for Location.addItem

### DIFF
--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -440,8 +440,29 @@ Location.prototype.flush = function flush() {
  *        with other nearby items
  */
 Location.prototype.addItem = function addItem(item, x, y, noMerge) {
+	if (!noMerge) {
+		for (var k in this.items) {
+			var it = this.items[k];
+			var dist = (x - it.x) * (x - it.x) + (y - it.y) * (y - it.y);
+			if (it.class_tsid === item.class_tsid && it.count < it.stackmax && 
+				dist < 10000) {
+				if (it.count + item.count > it.stackmax) {
+					item.count = it.count + item.count - it.stackmax;
+					it.count = it.stackmax;
+				}
+				else {
+					it.count = it.count + item.count;
+					item.count = 0;
+				}
+				it.setContainer(this, it.x, it.y);
+			}
+			if (!item.count) {
+				item.del();
+				return;
+			}
+		}
+	}
 	item.setContainer(this, x, y);
-	//TODO: merging
 };
 
 

--- a/test/func/model/Location.js
+++ b/test/func/model/Location.js
@@ -203,6 +203,22 @@ suite('Location', function () {
 				assert.strictEqual(locChg.y, 200);
 			}, done);
 		});
+		
+		test('merge stacks where possible', function (done) {
+			var rc = new RC();
+			rc.run(function () {
+				var l = Location.create(Geo.create());
+				var i1 = Item.create('apple', 50);
+				var i2 = Item.create('apple', 82);
+				var i3 = Item.create('apple', 30);
+				l.addItem(i1, 0, 0);
+				l.addItem(i2, 10, 10);
+				l.addItem(i3, 100, 100);
+				assert.strictEqual(i1.count, 100);
+				assert.strictEqual(i2.count, 32);
+				assert.strictEqual(i3.count, 30);
+			}, done);
+		});
 	});
 
 


### PR DESCRIPTION
* This allows items to merge with nearby stacks as long as the stack
count is not at stackmax. Anything leftover is added to the location as
a new itemstack.

Fixes https://trello.com/c/H9IlUmgo