### PR TITLE
Queue messages on gs location change

### DIFF
--- a/src/model/globalApi.js
+++ b/src/model/globalApi.js
@@ -38,7 +38,7 @@ function getItemType(classTsid) {
 
 function isPlayerOnline(tsid) {
 	var p = pers.get(tsid);
-	return p !== undefined && p.isConnected();
+	return p !== undefined && (p.isConnected() || p.isMovingGs);
 }
 
 

--- a/test/func/model/Player.js
+++ b/test/func/model/Player.js
@@ -295,5 +295,28 @@ suite('Player', function () {
 				}
 			);
 		});
+
+		test('cache messages on gs move', function (done) {
+			new RC().run(
+				function () {
+					var l = Location.create(Geo.create());
+					var p = new Player({tsid: 'PX', location: l});
+					var msg = {some: 'msg'};
+					p.session = {
+						send: function send(msg) {
+							assert.strictEqual(msg.some, 'msg');
+							done();
+						}
+					};
+					p.isMovingGs = true;
+					p.send(msg);
+					assert.lengthOf(p.msgCache, 1);
+					p.endMove();
+				},
+				function (err, res) {
+					if (err) return done(err);
+				}
+			);
+		});
 	});
 });


### PR DESCRIPTION
* When we call `Player.startMove` and the target location is on another GS, cache any incoming messages until we connect to the new GS and call `Player.endMove` where we send any cached messages.
* The global function `isPlayerOnline` should also return true if we are
moving between game servers.