### PR TITLE
Item animation improvements

### DIFF
--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -454,7 +454,7 @@ Location.prototype.flush = function flush() {
  *        with other nearby items
  */
 Location.prototype.addItem = function addItem(item, x, y, noMerge) {
-	var pc = this.players[item.dropper];
+	var pcont = item.container;
 	if (!item.animSourceTsid) {
 		item.animSourceTsid = item.tsid;
 	}
@@ -473,12 +473,12 @@ Location.prototype.addItem = function addItem(item, x, y, noMerge) {
 					it.count = it.count + item.count;
 					item.count = 0;
 				}
-				if (pc) {
-					pc.createStackAnim('pack_to_floor', item.class_tsid,
+				if (pcont && utils.isPlayer(pcont)) {
+					pcont.createStackAnim('pack_to_floor', item.class_tsid,
 						initial - item.count, {
 							dest_x: it.x,
 							dest_y: it.y,
-							orig_path: pc.tsid + '/' + item.animSourceTsid + '/',
+							orig_path: pcont.tsid + '/' + item.animSourceTsid + '/',
 						}
 					);
 				}
@@ -490,11 +490,11 @@ Location.prototype.addItem = function addItem(item, x, y, noMerge) {
 			}
 		}
 	}
-	if (pc) {
-		pc.createStackAnim('pack_to_floor', item.class_tsid, item.count, {
+	if (pcont && utils.isPlayer(pcont)) {
+		pcont.createStackAnim('pack_to_floor', item.class_tsid, item.count, {
 			dest_x: x,
 			dest_y: y,
-			orig_path: pc.tsid + '/' + item.animSourceTsid + '/',
+			orig_path: pcont.tsid + '/' + item.animSourceTsid + '/',
 		});
 	}
 	item.setContainer(this, x, y);

--- a/src/model/LocationApi.js
+++ b/src/model/LocationApi.js
@@ -69,8 +69,14 @@ LocationApi.prototype.apiAddStack = function apiAddStack(item, slot, path, amoun
 LocationApi.prototype.apiAddStackAnywhere = function apiAddStackAnywhere(item, maxSlot, path, amount, pc) {
 	log.debug('%s.apiAddStackAnywhere(%s, %s, %s, %s, %s)', this, item, maxSlot,
 		path, amount, pc);
-	return this.addToBag(item, 0, maxSlot, path, amount);
-	//TODO: item animation announcements from pc
+	var ret = this.addToBag(item, 0, maxSlot, path, amount);
+	if (pc) {
+		pc.createStackAnim('pack_to_bag', item.class_tsid, amount - ret, {
+			orig_path: pc.tsid + '/' + item.tsid + '/',
+			dest_path: path + '/',
+		});
+	}
+	return ret;
 };
 
 

--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -449,7 +449,11 @@ Player.prototype.addToAnySlot = function addToAnySlot(item, fromSlot, toSlot,
 	path, amount) {
 	if (amount === undefined || amount > item.count) amount = item.count;
 	var bag = path ? pers.get(path.split('/').pop()) : this;
-	var src = {x: item.x, y: item.y, tcont: item.tcont};
+	var src = {
+		x: item.x === 0 ? this.x : item.x,
+		y: item.y === 0 ? this.y : item.y,
+		tcont: item.tcont,
+	};
 	for (var slot = fromSlot; slot <= toSlot && amount > 0; slot++) {
 		var count = bag.addToSlot(item, slot, amount);
 		amount -= count;

--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -452,12 +452,18 @@ Player.prototype.addToAnySlot = function addToAnySlot(item, fromSlot, toSlot,
 	var src = {
 		x: item.x === 0 ? this.x : item.x,
 		y: item.y === 0 ? this.y : item.y,
-		tcont: item.tcont,
+		cont: item.container,
 	};
 	for (var slot = fromSlot; slot <= toSlot && amount > 0; slot++) {
 		var count = bag.addToSlot(item, slot, amount);
 		amount -= count;
-		if (count && src.tcont !== this.tsid) {
+		if (count && src.cont !== this) {
+			if (utils.isBag(src.cont) && !utils.isPlayer(src.cont)) {
+				src.x = src.cont.x;
+				src.y = src.cont.y;
+			}
+			var animSrc = (item.animSourceTsid === 'I-FAMILIAR' ? 'familiar_to_pack' :
+				'floor_to_pack');
 			var annc = {
 				orig_x: src.x,
 				orig_y: src.y,
@@ -467,7 +473,8 @@ Player.prototype.addToAnySlot = function addToAnySlot(item, fromSlot, toSlot,
 				annc.dest_path = this.tsid + '/' + bag.tsid + '/';
 				annc.dest_slot = slot;
 			}
-			this.createStackAnim('floor_to_pack', item.class_tsid, count, annc);
+			delete item.animSourceTsid;
+			this.createStackAnim(animSrc, item.class_tsid, count, annc);
 		}
 	}
 	return amount;

--- a/src/model/globalApi.js
+++ b/src/model/globalApi.js
@@ -247,11 +247,19 @@ exports.apiNewItemStackFromSource = function apiNewItemStackFromSource(
 };
 
 
+/**
+ * Creates a new itemstack from a players familiar (magic rock).
+ *
+ * @param {string} classTsid ID of the desired item class
+ * @param {number} count item stack amount (must be a positive integer)
+ * @returns {Item} the new object
+ */
 exports.apiNewItemStackFromFamiliar = function apiNewItemStackFromFamiliar(
 	classTsid, count) {
 	log.debug('global.apiNewItemStackFromFamiliar(%s, %s)', classTsid, count);
-	//TODO: adjust&document once itemstack animations are available
-	return getItemType(classTsid).create(classTsid, count);
+	var ret = getItemType(classTsid).create(classTsid, count);
+	ret.animSourceTsid = 'I-FAMILIAR';
+	return ret;
 };
 
 


### PR DESCRIPTION
Contains a bunch of improvements for client item animations, such as:

* Itemstack animations for familiars and bags.
* Change floor_to_pack aniamtions source location to the players position if it starts at 0, 0.
* Remove unnecessary animations when dragdropping by using an items previous container in pack_to_* animations rather than the dropper TSID.