### PR TITLE
Fix bugs with itemstacks and merging

### DIFF
--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -138,13 +138,17 @@ Item.create = function create(classTsid, count, x, y) {
 		'invalid class TSID for Item: %s', classTsid));
 	var data = {class_tsid: classTsid};
 	if (utils.isInt(count)) {
-		data.count = count;
+		data.count = parseInt(count);
 	}
 	if (utils.isInt(x) && utils.isInt(y)) {
 		data.x = x;
 		data.y = y;
 	}
-	return pers.create(Item, data);
+	var ret = pers.create(Item, data);
+	if (ret.count > ret.stackmax) {
+		ret.count = ret.stackmax;
+	}
+	return ret;
 };
 
 

--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -461,6 +461,9 @@ Location.prototype.addItem = function addItem(item, x, y, noMerge) {
 	if (!noMerge) {
 		for (var k in this.items) {
 			var it = this.items[k];
+			if (it === item) {
+				continue;
+			}
 			var dist = (x - it.x) * (x - it.x) + (y - it.y) * (y - it.y);
 			if (it.class_tsid === item.class_tsid && it.count < it.stackmax &&
 				dist < 10000) {

--- a/test/func/model/Item.js
+++ b/test/func/model/Item.js
@@ -35,11 +35,11 @@ suite('Item', function () {
 		test('does its job', function (done) {
 			new RC().run(
 				function () {
-					var it = Item.create('pi', 7);
+					var it = Item.create('pi', 5);
 					assert.isTrue(utils.isItem(it));
 					assert.strictEqual(it.class_tsid, 'pi');
 					assert.strictEqual(it.constructor.name, 'pi');
-					assert.strictEqual(it.count, 7);
+					assert.strictEqual(it.count, 5);
 				},
 				function cb(err, res) {
 					if (err) return done(err);
@@ -62,6 +62,20 @@ suite('Item', function () {
 			assert.throw(function () {
 				Item.create('bag_bigger_gray');
 			}, assert.AssertionError);
+		});
+
+		test('does not create items with count over stackmax', function (done) {
+			new RC().run(function () {
+				var it = Item.create('pi', 7);
+				assert.strictEqual(it.count, 5);
+			}, done);
+		});
+
+		test('does not create items with string item counts', function (done) {
+			new RC().run(function () {
+				var it = Item.create('pi', '5');
+				assert.strictEqual(it.count, 5);
+			}, done);
 		});
 	});
 


### PR DESCRIPTION
* The GSJS occasionally creates items with a string count. This leads to
obvious problems when we combine stacks. To fix this, we should always
create items with an integer count.
* Item.create allowed for items above stackmax. While this isn't
gamebreaking, we should limit created items to stackmax.
* Dragdrop uses `Location.addItem` to re-add the item in to the location
with different x/y coords. This resulted in the item being merged with
itself and then being deleted, which is bad!

Fixes https://trello.com/c/QLOvDWNU
Fixes https://trello.com/c/hOoHHhO8
Maybe fixes https://trello.com/c/JhX23GM7