### PR TITLE
Call onLoad outside of request queues

### DIFF
--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -59,7 +59,7 @@ utils.copyProps(require('model/GameObjectApi').prototype, GameObject.prototype);
  */
 GameObject.prototype.gsOnLoad = function gsOnLoad() {
 	if (this.onLoad) {
-		this.rqPush(this.onLoad);
+		this.onLoad();
 	}
 	this.resumeGsTimers();
 };


### PR DESCRIPTION
* `onLoad` MUST be called before `resumeGsTimers` as objects can be
deleted on interval catchup (trants, pigs, probably some other things).

Fixes https://trello.com/c/zvzKIiZx
Might fix https://trello.com/c/q0hLNhpB
Partial fix for https://trello.com/c/sFSHvH2a (error occurs when onLoad
fails due to missing container in most cases)