### PR TITLE
Ensure item stops moving on apiDelete call

### DIFF
--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -193,6 +193,7 @@ Item.prototype.del = function del() {
 	log.trace('del %s', this);
 	// TODO INFO msg for broken objref debugging, remove when no longer needed:
 	log.info('Item.del: %s', this);
+	this.gsStopMoving();
 	Item.super_.prototype.del.call(this);
 	if (this.container) {
 		RC.setDirty(this.container);

--- a/test/func/model/ItemMovement.js
+++ b/test/func/model/ItemMovement.js
@@ -296,6 +296,20 @@ suite('ItemMovement', function () {
 				}, 700);
 			}, 700);
 		});
+
+		test('item movement is stopped on item deletion', function (done) {
+			var i1 = newItem({tsid: 'I1', npc_walk_speed: 10, npc_y_step: 3});
+			i1.doneMoving = function doneMoving(args) {
+				if (args.status === STATUS.STOP) {
+					done();
+				}
+			};
+			addToTestLoc(i1, 18, 9, gPlat);
+			var moveStarted = i1.gsStartMoving('walking', {x: 2000, y: 10},
+				{callback: 'doneMoving'});
+			assert.isTrue(moveStarted);
+			i1.apiDelete();
+		});
 	});
 
 


### PR DESCRIPTION
* In the alpha pigs that had died (through apiDelete) would still have
item movement timers despite the item not existing. This sent changes to
the client which resulted in players seeing pigs that were not there. To
fix this, we should stop item movement before deleting the object.