### PR TITLE
Misc server improvements

### DIFF
--- a/src/data/pers.js
+++ b/src/data/pers.js
@@ -163,8 +163,6 @@ function load(tsid) {
 		}
 		catch (err) {
 			log.error(err, 'failed to process onLoad event');
-			delete cache[tsid];
-			return null;
 		}
 		metrics.increment('pers.load.local');
 	}

--- a/src/model/Player.js
+++ b/src/model/Player.js
@@ -560,7 +560,7 @@ Player.prototype.queueAnnc = function queueAnnc(annc) {
  *        there are changes and/or announcements to send along with it
  */
 Player.prototype.send = function send(msg, skipChanges, flushOnly) {
-	if (this.isMovingGs) {
+	if (this.isMovingGs && !this.session) {
 		log.info('queueing message during GS move for player %s', this);
 		this.msgCache.push(msg);
 		return;

--- a/src/model/globalApi.js
+++ b/src/model/globalApi.js
@@ -310,13 +310,13 @@ exports.apiNewLocation = function apiNewLocation(label, moteId, hubId, classTsid
  */
 exports.apiFindObject = function apiFindObject(tsid) {
 	log.trace('global.apiFindObject(%s)', tsid);
-	// GSJS code is calling this with invalid TSID, but does not expect it to
-	// throw (e.g. in groups/hi_variants_tracker.reset)
-	var ret = null;
-	if (gsjsBridge.isTsid(tsid)) {
-		ret = pers.get(tsid);
+	try {
+		return pers.get(tsid);
 	}
-	return ret;
+	catch (e) {
+		log.error(e, 'apiFindObject called with problematic tsid %s', tsid);
+	}
+	return null;
 };
 
 

--- a/test/func/model/Player.js
+++ b/test/func/model/Player.js
@@ -304,14 +304,14 @@ suite('Player', function () {
 					var l = Location.create(Geo.create());
 					p = new Player({tsid: 'PX', location: l});
 					var msg = {some: 'msg'};
+					p.isMovingGs = true;
+					p.send(msg);
+					assert.lengthOf(p.msgCache, 1);
 					p.session = {
 						send: function send(msg) {
 							sent.push(msg);
 						},
 					};
-					p.isMovingGs = true;
-					p.send(msg);
-					assert.lengthOf(p.msgCache, 1);
 					p.endMove();
 				},
 				function (err, res) {

--- a/test/unit/data/pers.js
+++ b/test/unit/data/pers.js
@@ -88,8 +88,8 @@ suite('pers', function () {
 			};
 			pbeMock.write([o]);
 			var loaded = load(o.tsid);
-			assert.isNull(loaded);
-			assert.notProperty(pers.__get__('cache'), o.tsid);
+			assert.strictEqual(loaded, o);
+			assert.property(pers.__get__('cache'), o.tsid);
 		});
 
 		test('does not choke on objref cycles', function () {


### PR DESCRIPTION
* During a gs move, do not cache messages if the player still has a
session.
* Do not return `null` if an error occurs processing `onLoad` in
`pers.get`. This would falsely result in a "referenced object not found"
error.
* Catch any errors that occur in the global api function
`apiFindObject`. Any errors will be logged and `null` will be returned.