### PR TITLE
Index bag slots

### DIFF
--- a/src/model/Bag.js
+++ b/src/model/Bag.js
@@ -31,6 +31,7 @@ function Bag(data) {
 	if (!('capacity' in this)) this.capacity = 16;
 	this.items = new IdObjRefMap(this.items);
 	this.hiddenItems = new IdObjRefMap(this.hiddenItems);
+	utils.addNonEnumerable(this, 'index');
 }
 
 utils.copyProps(require('model/BagApi').prototype, Bag.prototype);
@@ -221,12 +222,10 @@ Bag.prototype.getClassItems = function getClassItems(classTsid, minCount) {
  */
 Bag.prototype.getSlot = function getSlot(slot) {
 	slot = utils.intVal(slot);
-	for (var k in this.items) {
-		if (this.items[k].x === slot) {
-			return this.items[k];
-		}
+	if (!this.index) {
+		this.index = this.getSlots();
 	}
-	return null;
+	return this.index[slot] ? this.index[slot] : null;
 };
 
 

--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -196,6 +196,9 @@ Item.prototype.del = function del() {
 	this.gsStopMoving();
 	Item.super_.prototype.del.call(this);
 	if (this.container) {
+		if (this.container.index) {
+			this.container.index[this.x] = null;
+		}
 		RC.setDirty(this.container);
 		delete this.container.items[this.tsid];
 		delete this.container.hiddenItems[this.tsid];
@@ -288,6 +291,13 @@ Item.prototype.setContainer = function setContainer(cont, x, y, hidden) {
 		}
 		RC.setDirty(cont);
 		cont[hidden ? 'hiddenItems' : 'items'][this.tsid] = this;
+	}
+	// update indices
+	if (prev && prev.index) {
+		prev.index[this.x] = null;
+	}
+	if (cont.index) {
+		cont.index[x] = this;
 	}
 	// queue removal change if top container changed
 	if (tcont !== this.tcont) {


### PR DESCRIPTION
* `Bag.getSlot` currently goes through all of the stacks in `items`
until it finds the correct `x` or slot. This results in performance
issues with bags that have a large number of items such as SDBs. To fix
this, create an index using `Bag.getSlots` and keep it updated when an
items container is changed.

Fixes https://trello.com/c/i7S7x7Nm