### PR TITLE
Check if recipient is online in apiSendToGroup

### DIFF
--- a/src/model/globalApi.js
+++ b/src/model/globalApi.js
@@ -38,7 +38,7 @@ function getItemType(classTsid) {
 
 function isPlayerOnline(tsid) {
 	var p = pers.get(tsid);
-	return p !== undefined && (p.isConnected() || p.isMovingGs);
+	return p !== undefined && (p.isConnected() || p.isMovingGs !== undefined);
 }
 
 
@@ -494,7 +494,9 @@ exports.apiSendToGroup = function apiSendToGroup(msg, recipients) {
 	recipients = _.map(utils.playersArgToList(recipients), pers.get);
 	async.each(recipients, function send(recipient, cb) {
 		try {
-			recipient.send(msg, true);
+			if (isPlayerOnline(recipient.tsid)) {
+				recipient.send(msg, true);
+			}
 		}
 		catch (err) {
 			log.error(err, 'error delivering group message to %s', recipient.tsid);


### PR DESCRIPTION
* Check if a player is online before calling `send`. This cuts down on
the amount of "dropped message to offline player" spam in the logs.
* Minor fix to `isPlayerOnline` which now returns `false` if a player is
offline. Previously it would return `undefined`.