### PR TITLE
Clamp flying transport with stopAtEnd option

### DIFF
--- a/src/model/ItemMovement.js
+++ b/src/model/ItemMovement.js
@@ -858,8 +858,8 @@ ItemMovement.prototype.buildPath = function buildPath(transport, dest) {
 		}
 		else {
 			path = [{
-				x: dest.x,
-				y: dest.y,
+				x: geo.limitX(dest.x),
+				y: geo.limitY(dest.y),
 				speed: this.options.speed,
 				stopAtEnd: true,
 				transport: 'flying',


### PR DESCRIPTION
* Fireflies with the `stopAtEnd` option enabled could find their way
outside of the location boundaries. Clamping the destination x/y to the
location boundaries fixes this.