### PR TITLE
Remove broken refs from locations items in gsOnLoad

### DIFF
--- a/src/model/Location.js
+++ b/src/model/Location.js
@@ -91,6 +91,8 @@ Location.prototype.gsOnLoad = function gsOnLoad() {
 	// on demand, but this makes the logs easier to grok)
 	this.getRQ();
 	this.startUnloadInterval();
+	// remove broken item refs in locations item list
+	pers.clearStaleRefs(this, 'items');
 	// clean up stale instance group references
 	var instances = _.get(this, 'instances.instances', {});
 	for (var k in instances) {


### PR DESCRIPTION
* Instead of keeping players from being able to play or enter a location due to persisted bad references, delete them when calling `gsOnLoad`

(This does not fix the underlying issue, but allows players to continue playing the game)