### PR TITLE
Avoid resolving objrefs on serialization

### DIFF
--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -96,7 +96,7 @@ GameObject.prototype.serialize = function serialize() {
 		var k = keys[i];
 		if (k[0] !== '!') {
 			var val = this[k];
-			if (!_.isFunction(val)) {
+			if ((val && val.__isORP) || !_.isFunction(val)) {
 				ret[k] = val;
 			}
 		}


### PR DESCRIPTION
* Serializing a Player game object will result in certain DCs being resolved and staying in the GS cache indefinitely. This is caused by the lodash function `isFunction` which resolves the proxy, and is fixed through short circuit evaluation, checking if the value is an ORP beforehand.