### PR TITLE
Pass the player as an ORP to the gsjs

### DIFF
--- a/src/comm/Session.js
+++ b/src/comm/Session.js
@@ -15,6 +15,7 @@ var domain = require('domain');
 var events = require('events');
 var pers = require('data/pers');
 var rpc = require('data/rpc');
+var orp = require('data/objrefProxy');
 var util = require('util');
 var RQ = require('data/RequestQueue');
 var gsjsBridge = require('model/gsjsBridge');
@@ -270,7 +271,7 @@ Session.prototype.processRequest = function processRequest(req) {
 	log.trace({data: req}, 'handling %s request', req.type);
 	var abort = this.preRequestProc(req);
 	if (abort) return;
-	this.gsjsProcessMessage(this.pc, req);
+	this.gsjsProcessMessage(orp.makeProxy(this.pc), req);
 	this.postRequestProc(req);
 };
 

--- a/src/data/pers.js
+++ b/src/data/pers.js
@@ -504,6 +504,9 @@ function del(tsids, logtag, callback) {
 function unload(tsid, logmsg) {
 	log.debug('pers.unload: %s%s', tsid, logmsg ? ' (' + logmsg + ')' : '');
 	if (tsid in cache) {
+		// check to see if the player is gs moving and send the relevant
+		// messages if they are.
+		if (cache[tsid].sendGsMoveMsg) cache[tsid].sendGsMoveMsg();
 		// suspend timers/intervals
 		cache[tsid].suspendGsTimers();
 		delete cache[tsid];

--- a/src/model/GameObject.js
+++ b/src/model/GameObject.js
@@ -136,6 +136,18 @@ GameObject.prototype.toString = function toString() {
 
 
 /**
+ * Checks to see if two GameObjects are equal. This is currently just by
+ * comparing their TSIDs.
+ *
+ * @param {GameObject} [obj] object to compare against
+ * @returns {boolean} `true` if the GOs are the same
+ */
+GameObject.prototype.equals = function equals(obj) {
+	return obj instanceof GameObject ? this.tsid === obj.tsid : false;
+};
+
+
+/**
  * Schedules this object to be released from the live object cache after the
  * current request.
  */

--- a/test/unit/model/Player.js
+++ b/test/unit/model/Player.js
@@ -366,9 +366,8 @@ suite('Player', function () {
 			'unloads player', function (done) {
 			rpcMock.reset(false);
 			var p = new Player({tsid: 'P1', onGSLogout: _.noop});
-			var unloaded = false;
 			p.unload = function () {
-				unloaded = true;
+				p.sendGsMoveMsg();
 			};
 			var msgs = [];
 			p.session = {send: function send(msg) {
@@ -382,7 +381,6 @@ suite('Player', function () {
 						});
 						break;
 					case 1:
-						assert.isTrue(unloaded);
 						assert.deepEqual(msg, {
 							type: 'server_message',
 							action: 'CLOSE',
@@ -396,6 +394,7 @@ suite('Player', function () {
 				if (msgs.length > 1) return done();
 			}};
 			new RC().run(function () {
+				p.isMovingGs = true;
 				p.gsMoveCheck('LREMOTE');
 			});
 		});


### PR DESCRIPTION
* Passing the players info directly to the GSJS has the unintended side effect of creating copies of the Player on other objects (gravestones, party chat). If the copy is not persisted and the player goes offline, functions called on the reference stored in other objects will not modify the Player object. To fix this, we should pass an ORP to the gsjs.

This fix will require some gsjs changes, as some comparisons fail due to the use of objrefs (quoin sharding, hi messages).