### PR TITLE
Avoid RPC races

### DIFF
--- a/src/comm/slackChat.js
+++ b/src/comm/slackChat.js
@@ -197,9 +197,9 @@ function onSlackMessage(msg) {
 		return;
 	}
 	if (user.id === slack.activeUserId) {
-        // don't echo!
-        return;
-    }
+		// don't echo!
+		return;
+	}
 	var out = {
 		type: 'pc_groups_chat',
 		tsid: groupTsid,

--- a/src/data/RequestQueue.js
+++ b/src/data/RequestQueue.js
@@ -203,8 +203,10 @@ RequestQueue.prototype.push = function push(tag, func, callback, options) {
 	if (callback) entry.callback = callback;
 	if (options) entry.options = options;
 	// handle requests belonging to the same context as the currently active
-	// request (typically nested RPCs) directly, to avoid deadlocks
-	if (this.inProgress && tag && tag.startsWith(this.inProgress.tag)) {
+	// request (typically nested RPCs) or requests where the RQ is currently busy
+	// waiting for an RPC response directly, to avoid deadlocks
+	if (this.inProgress && tag && tag.startsWith(this.inProgress.tag) ||
+		this.rpcWait) {
 		entry.nested = true;
 		setImmediate(this.handle.bind(this, entry, true));
 	}

--- a/src/data/rpc.js
+++ b/src/data/rpc.js
@@ -335,14 +335,18 @@ function sendRequest(gsid, rpcFunc, args, callback) {
 		});
 	}
 	else {
+        var rc = RC.getContext(true);
 		try {
+			if (rc && rc.rq) rc.rq.rpcWait = true;
 			var res = wait.forMethod(client, 'request', rpcFunc, rpcArgs);
+			if (rc && rc.rq) delete rc.rq.rpcWait;
 			// wrapping to handle the special case where res is an objref itself
 			var wrap = {res: res};
 			orProxy.proxify(wrap);
 			return wrap.res;
 		}
 		catch (e) {
+            if (rc && rc.rq) delete rc.rq.rpcWait;
 			throw new RpcError('error calling ' + logmsg, e);
 		}
 	}


### PR DESCRIPTION
* If two servers RPC eachother at the same time, it may lead to a race if the requests are pushed to RQs that are waiting for RPC responses. To avoid this, mark the RQ as waiting for an RPC response, and check for this when pushing to it.

fixes https://trello.com/c/glgN2tVw and probably any other instances of "RPC Timed out" errors.