### PR TITLE
Fetch new unpersisted GOs through RPC

### DIFF
--- a/src/data/pers.js
+++ b/src/data/pers.js
@@ -150,6 +150,17 @@ function load(tsid) {
 	assert(pbe, 'persistence back-end not set');
 	log.debug('pers.load: %s', tsid);
 	var data = pbe.read(tsid);
+	if (data === null && (utils.isGeo(tsid) || utils.isLoc(tsid) || utils.isGroup(tsid)) &&
+		!rpc.isLocal(tsid)) {
+		// if the object in question is managed by another gs, see if it has data on it
+		log.info('no data for %s, but managed by another gs', tsid);
+		try {
+			data = rpc.sendObjRequest(tsid, 'serialize');
+		}
+		catch (e) {
+			log.error(e, 'could not load data for %s on other gs', tsid);
+		}
+	}
 	if (data === null && (utils.isGeo(tsid) || utils.isLoc(tsid))) {
 		log.info('no data for %s, using temp location data instead', tsid);
 		data = pbe.read(utils.isGeo(tsid) ? 'GKZ8WU4WGMQME7CXXX' : 'LKZ8WU4WGMQME7CXXX');


### PR DESCRIPTION
* If a server creates a new GO, and it is accessed in the same request by another server, just fetch a serialised copy so we have something to work with.

fixes https://trello.com/c/iWFIJYO5