### PR TITLE
Do not refify objects scheduled for deletion

### DIFF
--- a/src/data/objrefProxy.js
+++ b/src/data/objrefProxy.js
@@ -251,6 +251,10 @@ function refify(data, ret) {
 			ret[k] = v;
 		}
 		else if (v.__isORP || v.__isGO) {
+			// do not make refs for deleted GOs.
+			if (!v.__isORP && v.deleted) {
+				continue;
+			}
 			ret[k] = makeRef(v);
 		}
 		else {

--- a/test/unit/data/objrefProxy.js
+++ b/test/unit/data/objrefProxy.js
@@ -258,5 +258,12 @@ suite('objrefProxy', function () {
 			assert.isFalse('label' in refd, 'resulting objref does not have ' +
 				'a "label" property');
 		});
+
+		test('does not refify objects scheduled for deletion', function() {
+			var o = [new GameObject({tsid: 'IDELETEME'})];
+			o[0].apiDelete();
+			var refd = orproxy.refify(o);
+			assert.strictEqual(refd.length, 0);
+		});
 	});
 });


### PR DESCRIPTION
* Instead of checking to see if references are valid on persistence load (as this defeats the purpose of ORPs), we should check to see if a GO has been deleted before refifying. This should hopefully stop the gs from storing refs of deleted items.

Fixes https://trello.com/c/GZpLvL3j