### PR TITLE
Do not call container change events for deleted items

### DIFF
--- a/src/model/Item.js
+++ b/src/model/Item.js
@@ -330,6 +330,10 @@ Item.prototype.sendContChangeEvents = function sendContChangeEvents(prev) {
 			for (k in prev.items) {
 				it = prev.items[k];
 				if (it && it.onContainerItemRemoved) {
+					if (it.deleted) {
+						log.warn('skipping onContainerItemRemoved for deleted item %s', it);
+						continue;
+					}
 					it.rqPush(it.onContainerItemRemoved, this, cont);
 				}
 			}
@@ -339,6 +343,10 @@ Item.prototype.sendContChangeEvents = function sendContChangeEvents(prev) {
 		for (k in cont.items) {
 			it = cont.items[k];
 			if (it && it.onContainerItemAdded) {
+				if (it.deleted) {
+					log.warn('skipping onContainerItemAdded for deleted item %s', it);
+					continue;
+				}
 				it.rqPush(it.onContainerItemAdded, this, prev);
 			}
 		}


### PR DESCRIPTION
* While we should not have references to deleted items hanging around, we should also avoid calling container change events on items that have been deleted.