### PR TITLE
Ignore null values in IdObjRefMap constructor

### DIFF
--- a/src/model/IdObjRefMap.js
+++ b/src/model/IdObjRefMap.js
@@ -24,6 +24,10 @@ function IdObjRefMap(data) {
 	}
 	for (var i = 0; data && i < data.length; i++) {
 		var obj = data[i];
+		if (!_.isObject(obj)) {
+			// ignore values that aren't objects
+			continue;
+		}
 		if (obj.__isORP) {
 			orProxy.setupObjRefProp(obj.tsid, this, obj.tsid);
 		}


### PR DESCRIPTION
* null values here could be happening due to the use of delete over splice on an array, but lets fix the
issue here as we can safely ignore nulls (and anything else that isn't an object).